### PR TITLE
Add tests for stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+nupkgs/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # RevitExtensions
+
+This repository contains helper extensions for the Autodesk Revit API. The goal is to make it easier to use APIs across Revit versions. One important helper is retrieving an element id as a `long` value regardless of the Revit release. The library depends on the `Revit_All_Main_Versions_API_x64` NuGet package and builds against either .NET Framework 4.8 or .NET 8 depending on the Revit version. A tiny `RevitApiStubs` project is included for unit tests so they can run without Autodesk binaries.
+
+## Building packages
+
+Run `./pack.sh` to build NuGet packages for Revit versions 2019 through 2026.
+Packages will be written to the `nupkgs` directory.
+
+## Running tests
+
+The test project uses the `RevitApiStubs` library so no Autodesk binaries are
+required. Run tests with defines for a specific Revit version, for example:
+
+```bash
+dotnet test RevitExtensions.sln -c Release \
+  -p:UseRevitApiStubs=true \
+  -p:DefineConstants=REVIT2026%3BREVIT2026_OR_ABOVE%3BREVIT2025_OR_ABOVE%3BREVIT2024_OR_ABOVE
+```

--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -1,0 +1,26 @@
+namespace Autodesk.Revit.DB
+{
+    /// <summary>
+    /// Represents a stable persistent identifier for elements.
+    /// Only the relevant properties for extension methods are modeled.
+    /// </summary>
+    public class ElementId
+    {
+#if REVIT2024_OR_ABOVE
+        public long Value { get; }
+        public ElementId(long value) => Value = value;
+#else
+        public int IntegerValue { get; }
+        public ElementId(int value) => IntegerValue = value;
+#endif
+    }
+
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.Element exposing only the Id property.
+    /// </summary>
+    public class Element
+    {
+        public ElementId Id { get; }
+        public Element(ElementId id) => Id = id;
+    }
+}

--- a/RevitApiStubs/RevitApiStubs.csproj
+++ b/RevitApiStubs/RevitApiStubs.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <ImplicitUsings>false</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+</Project>

--- a/RevitExtensions.Tests/ElementExtensionsTests.cs
+++ b/RevitExtensions.Tests/ElementExtensionsTests.cs
@@ -1,0 +1,24 @@
+using Autodesk.Revit.DB;
+using RevitExtensions;
+using Xunit;
+
+namespace RevitExtensions.Tests
+{
+    public class ElementExtensionsTests
+    {
+        [Fact]
+        public void GetElementIdValue_FromElementId_ReturnsValue()
+        {
+            var id = new ElementId(42);
+            Assert.Equal(42L, id.GetElementIdValue());
+        }
+
+        [Fact]
+        public void GetElementIdValue_FromElement_ReturnsValue()
+        {
+            var id = new ElementId(99);
+            var element = new Element(id);
+            Assert.Equal(99L, element.GetElementIdValue());
+        }
+    }
+}

--- a/RevitExtensions.Tests/RevitExtensions.Tests.csproj
+++ b/RevitExtensions.Tests/RevitExtensions.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RevitExtensions\RevitExtensions.csproj" />
+    <ProjectReference Include="..\RevitApiStubs\RevitApiStubs.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.6.6" />
+  </ItemGroup>
+</Project>

--- a/RevitExtensions.sln
+++ b/RevitExtensions.sln
@@ -1,0 +1,62 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitExtensions", "RevitExtensions\RevitExtensions.csproj", "{9DCC4607-B317-41AD-962D-B4A38F4A60D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitApiStubs", "RevitApiStubs\RevitApiStubs.csproj", "{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitExtensions.Tests", "RevitExtensions.Tests\RevitExtensions.Tests.csproj", "{A41418FA-8743-4915-BF8A-6AE8797AC213}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Debug|x64.Build.0 = Debug|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Debug|x86.Build.0 = Debug|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Release|x64.ActiveCfg = Release|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Release|x64.Build.0 = Release|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Release|x86.ActiveCfg = Release|Any CPU
+		{9DCC4607-B317-41AD-962D-B4A38F4A60D1}.Release|x86.Build.0 = Release|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Debug|x64.Build.0 = Debug|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Debug|x86.Build.0 = Debug|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Release|x64.Build.0 = Release|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{8BD411CA-BEE0-4C80-9F49-CB0153A0E4A1}.Release|x86.Build.0 = Release|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Debug|x64.Build.0 = Debug|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Debug|x86.Build.0 = Debug|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Release|x64.ActiveCfg = Release|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Release|x64.Build.0 = Release|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Release|x86.ActiveCfg = Release|Any CPU
+		{A41418FA-8743-4915-BF8A-6AE8797AC213}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/RevitExtensions/ElementExtensions.cs
+++ b/RevitExtensions/ElementExtensions.cs
@@ -1,0 +1,38 @@
+using System;
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Extension methods for Autodesk Revit elements.
+    /// </summary>
+    public static class ElementExtensions
+    {
+        /// <summary>
+        /// Gets the numeric id of the element as a <see cref="long"/> regardless of Revit version.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <returns>The element id as a long.</returns>
+        public static long GetElementIdValue(this Element element)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            return element.Id.GetElementIdValue();
+        }
+
+        /// <summary>
+        /// Gets the numeric value of the element id as a <see cref="long"/>.
+        /// Handles Revit versions prior to 2024 where the value was stored as an <see cref="int"/>.
+        /// </summary>
+        /// <param name="id">The element id.</param>
+        /// <returns>The id value as a long.</returns>
+        public static long GetElementIdValue(this ElementId id)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+#if REVIT2024_OR_ABOVE
+            return id.Value;
+#else
+            return id.IntegerValue;
+#endif
+        }
+    }
+}

--- a/RevitExtensions/RevitExtensions.csproj
+++ b/RevitExtensions/RevitExtensions.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Description>Helper extensions for Autodesk Revit API.</Description>
+    <PackageId>RevitExtensions</PackageId>
+    <Authors>RevitExtensions</Authors>
+    <PackageTags>Revit;API;Extensions</PackageTags>
+    <!-- Default Revit API package version; overridden during packaging -->
+    <RevitApiPackageVersion>2026.0.0</RevitApiPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UseRevitApiStubs)' == 'true'">
+    <ProjectReference Include="..\RevitApiStubs\RevitApiStubs.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseRevitApiStubs)' != 'true'">
+    <PackageReference Include="Revit_All_Main_Versions_API_x64" Version="$(RevitApiPackageVersion)" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/pack.sh
+++ b/pack.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+
+OUTPUT=$(pwd)/nupkgs
+mkdir -p "$OUTPUT"
+
+for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
+  if [ "$year" -ge 2025 ]; then
+    tf=net8.0
+  else
+    tf=net48
+  fi
+
+  case $year in
+    2019) api_ver=2019.0.1 ;;
+    2020) api_ver=2020.0.1 ;;
+    2021) api_ver=2021.1.9 ;;
+    2022) api_ver=2022.1.0 ;;
+    2023) api_ver=2023.0.0 ;;
+    2024) api_ver=2024.2.0 ;;
+    2025) api_ver=2025.0.0 ;;
+    2026) api_ver=2026.0.0 ;;
+  esac
+
+  # build define constants
+  defines="REVIT${year}"
+  for y in {2019..2026}; do
+    if [ "$year" -ge "$y" ]; then
+      defines+=";REVIT${y}_OR_ABOVE"
+    fi
+    if [ "$year" -le "$y" ]; then
+      defines+=";REVIT${y}_OR_LESS"
+    fi
+  done
+
+  encoded_defs=${defines//;/\%3B}
+  dotnet msbuild RevitExtensions/RevitExtensions.csproj -t:pack \
+    -p:Configuration=Release \
+    -p:PackageVersion=1.0.0-revit${year} \
+    -p:PackageId=RevitExtensions${year} \
+    -p:PackageOutputPath="$OUTPUT" \
+    -p:TargetFramework=${tf} \
+    -p:DefineConstants=${encoded_defs} \
+    -p:RevitApiPackageVersion=${api_ver} \
+    -p:UseRevitApiStubs=false
+done


### PR DESCRIPTION
## Summary
- add `RevitExtensions.Tests` project using xUnit and RevitApiStubs
- verify `GetElementIdValue` on `Element` and `ElementId`
- document how to run tests with compiler constants

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true -p:DefineConstants=REVIT2026%3BREVIT2026_OR_ABOVE%3BREVIT2025_OR_ABOVE%3BREVIT2024_OR_ABOVE`


------
https://chatgpt.com/codex/tasks/task_e_6851236ab5748326b3b8863027dab3fd