### PR TITLE
Add disposal logic to ForEach

### DIFF
--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Autodesk.Revit.DB
 {
     /// <summary>
@@ -18,9 +20,123 @@ namespace Autodesk.Revit.DB
     /// <summary>
     /// Minimal stand-in for Autodesk.Revit.DB.Element exposing only the Id property.
     /// </summary>
-    public class Element
+    public class Element : IDisposable
     {
         public ElementId Id { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="Dispose"/> has been called.
+        /// </summary>
+        public bool IsDisposed { get; private set; }
+
         public Element(ElementId id) => Id = id;
+
+        /// <summary>
+        /// Disposes the element. In the stubs this simply sets <see cref="IsDisposed"/>.
+        /// </summary>
+        public void Dispose() => IsDisposed = true;
+    }
+
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.Document.
+    /// </summary>
+    public class Document { }
+
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.FilteredElementCollector capturing
+    /// the document and type filter.
+    /// </summary>
+    public class FilteredElementCollector : System.Collections.Generic.IEnumerable<Element>
+    {
+        public Document Document { get; }
+        public Type FilterType { get; private set; }
+        public BuiltInCategory? Category { get; private set; }
+        public System.Collections.Generic.IList<BuiltInCategory> Categories { get; private set; }
+        public bool ExcludesElementTypes { get; private set; }
+
+        private readonly System.Collections.Generic.List<Element> _elements = new System.Collections.Generic.List<Element>();
+
+        public FilteredElementCollector(Document document)
+        {
+            Document = document;
+        }
+
+        public void AddElement(Element element) => _elements.Add(element);
+
+        public System.Collections.Generic.IEnumerator<Element> GetEnumerator() => _elements.GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public FilteredElementCollector OfClass(Type type)
+        {
+            FilterType = type;
+            return this;
+        }
+
+        public FilteredElementCollector WherePasses(ElementCategoryFilter filter)
+        {
+            Category = filter.Category;
+            return this;
+        }
+
+        public FilteredElementCollector WherePasses(ElementMulticategoryFilter filter)
+        {
+            Categories = filter.Categories;
+            return this;
+        }
+
+        public FilteredElementCollector WhereElementIsNotElementType()
+        {
+            ExcludesElementTypes = true;
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Enumeration of built-in Revit categories. Only the members required for
+    /// unit tests are included.
+    /// </summary>
+    public enum BuiltInCategory
+    {
+        /// <summary>
+        /// Generic model elements.
+        /// </summary>
+        GenericModel
+    }
+
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.Wall used in tests.
+    /// </summary>
+    public class Wall : Element
+    {
+        public Wall(ElementId id) : base(id) { }
+    }
+
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.ElementCategoryFilter capturing
+    /// the category passed to the collector.
+    /// </summary>
+    public class ElementCategoryFilter
+    {
+        public BuiltInCategory Category { get; }
+
+        public ElementCategoryFilter(BuiltInCategory category)
+        {
+            Category = category;
+        }
+    }
+
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.ElementMulticategoryFilter capturing
+    /// the categories passed to the collector.
+    /// </summary>
+    public class ElementMulticategoryFilter
+    {
+        public System.Collections.Generic.IList<BuiltInCategory> Categories { get; }
+
+        public ElementMulticategoryFilter(System.Collections.Generic.IList<BuiltInCategory> categories)
+        {
+            Categories = categories;
+        }
     }
 }

--- a/RevitExtensions.Tests/DocumentExtensionsTests.cs
+++ b/RevitExtensions.Tests/DocumentExtensionsTests.cs
@@ -1,0 +1,43 @@
+using Autodesk.Revit.DB;
+using RevitExtensions;
+using Xunit;
+
+namespace RevitExtensions.Tests
+{
+    public class DocumentExtensionsTests
+    {
+        [Fact]
+        public void InstancesOf_Type_ReturnsCollectorWithDocumentAndType()
+        {
+            var doc = new Document();
+            var collector = doc.InstancesOf<Wall>();
+
+            Assert.Same(doc, collector.Document);
+            Assert.Equal(typeof(Wall), collector.FilterType);
+            Assert.True(collector.ExcludesElementTypes);
+        }
+
+        [Fact]
+        public void InstancesOf_Category_ReturnsCollectorWithDocumentAndCategory()
+        {
+            var doc = new Document();
+            var collector = doc.InstancesOf(BuiltInCategory.GenericModel);
+
+            Assert.Same(doc, collector.Document);
+            Assert.Equal(BuiltInCategory.GenericModel, collector.Category);
+            Assert.True(collector.ExcludesElementTypes);
+        }
+
+        [Fact]
+        public void InstancesOf_Categories_ReturnsCollectorWithDocumentAndCategories()
+        {
+            var doc = new Document();
+            var cats = new[] { BuiltInCategory.GenericModel, BuiltInCategory.GenericModel };
+            var collector = doc.InstancesOf(cats);
+
+            Assert.Same(doc, collector.Document);
+            Assert.Equal(cats, collector.Categories);
+            Assert.True(collector.ExcludesElementTypes);
+        }
+    }
+}

--- a/RevitExtensions.Tests/FilteredElementCollectorExtensionsTests.cs
+++ b/RevitExtensions.Tests/FilteredElementCollectorExtensionsTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Autodesk.Revit.DB;
+using RevitExtensions;
+using Xunit;
+
+namespace RevitExtensions.Tests
+{
+    public class FilteredElementCollectorExtensionsTests
+    {
+        [Fact]
+        public void ForEach_InvokesActionForEachElement()
+        {
+            var doc = new Document();
+            var collector = new FilteredElementCollector(doc)
+                .InstancesOf<Wall>();
+
+            var e1 = new Wall(new ElementId(1));
+            var e2 = new Wall(new ElementId(2));
+            collector.AddElement(e1);
+            collector.AddElement(e2);
+
+            var results = new List<Element>();
+            collector.ForEach(results.Add);
+
+            Assert.Equal(new[] { e1, e2 }, results);
+            Assert.True(e1.IsDisposed);
+            Assert.True(e2.IsDisposed);
+        }
+
+        [Fact]
+        public void InstancesOf_MultiCategories_FiltersCollector()
+        {
+            var doc = new Document();
+            var cats = new[] { BuiltInCategory.GenericModel, BuiltInCategory.GenericModel };
+            var collector = new FilteredElementCollector(doc)
+                .InstancesOf(cats);
+
+            Assert.Equal(cats, collector.Categories);
+            Assert.True(collector.ExcludesElementTypes);
+        }
+    }
+}

--- a/RevitExtensions/DocumentExtensions.cs
+++ b/RevitExtensions/DocumentExtensions.cs
@@ -1,0 +1,57 @@
+using System;
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="Document"/>.
+    /// </summary>
+    public static class DocumentExtensions
+    {
+        /// <summary>
+        /// Creates a collector for elements of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="document">The document to search.</param>
+        /// <returns>A filtered element collector for instances of <typeparamref name="T"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> is null.</exception>
+        public static FilteredElementCollector InstancesOf<T>(this Document document) where T : Element
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return new FilteredElementCollector(document)
+                .InstancesOf<T>();
+        }
+
+        /// <summary>
+        /// Creates a collector for elements in the specified built-in category.
+        /// </summary>
+        /// <param name="document">The document to search.</param>
+        /// <param name="category">The built-in category to filter by.</param>
+        /// <returns>A collector filtered by the given category.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> is null.</exception>
+        public static FilteredElementCollector InstancesOf(this Document document, BuiltInCategory category)
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return new FilteredElementCollector(document)
+                .InstancesOf(category);
+        }
+
+        /// <summary>
+        /// Creates a collector for elements in the specified built-in categories.
+        /// </summary>
+        /// <param name="document">The document to search.</param>
+        /// <param name="categories">The built-in categories to filter by.</param>
+        /// <returns>A collector filtered by the given categories.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> or <paramref name="categories"/> is null.</exception>
+        public static FilteredElementCollector InstancesOf(this Document document, System.Collections.Generic.IEnumerable<BuiltInCategory> categories)
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (categories == null) throw new ArgumentNullException(nameof(categories));
+
+            return new FilteredElementCollector(document)
+                .InstancesOf(categories);
+        }
+    }
+}

--- a/RevitExtensions/FilteredElementCollectorExtensions.cs
+++ b/RevitExtensions/FilteredElementCollectorExtensions.cs
@@ -1,0 +1,101 @@
+using System;
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="FilteredElementCollector"/>.
+    /// </summary>
+    public static class FilteredElementCollectorExtensions
+    {
+        /// <summary>
+        /// Filters the collector for instances of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="collector">The collector to filter.</param>
+        /// <returns>The filtered collector.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="collector"/> is null.</exception>
+        public static FilteredElementCollector InstancesOf<T>(this FilteredElementCollector collector) where T : Element
+        {
+            if (collector == null) throw new ArgumentNullException(nameof(collector));
+
+            return collector
+                .OfClass(typeof(T))
+                .WhereElementIsNotElementType();
+        }
+
+        /// <summary>
+        /// Filters the collector for instances in the specified category.
+        /// </summary>
+        /// <param name="collector">The collector to filter.</param>
+        /// <param name="category">The built-in category.</param>
+        /// <returns>The filtered collector.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="collector"/> is null.</exception>
+        public static FilteredElementCollector InstancesOf(this FilteredElementCollector collector, BuiltInCategory category)
+        {
+            if (collector == null) throw new ArgumentNullException(nameof(collector));
+
+            var filter = new ElementCategoryFilter(category);
+            return collector
+                .WherePasses(filter)
+                .WhereElementIsNotElementType();
+        }
+
+        /// <summary>
+        /// Filters the collector for instances in the specified categories.
+        /// </summary>
+        /// <param name="collector">The collector to filter.</param>
+        /// <param name="categories">The built-in categories.</param>
+        /// <returns>The filtered collector.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="collector"/> or <paramref name="categories"/> is null.</exception>
+        public static FilteredElementCollector InstancesOf(this FilteredElementCollector collector, System.Collections.Generic.IEnumerable<BuiltInCategory> categories)
+        {
+            if (collector == null) throw new ArgumentNullException(nameof(collector));
+            if (categories == null) throw new ArgumentNullException(nameof(categories));
+
+            var list = new System.Collections.Generic.List<BuiltInCategory>(categories);
+            var filter = new ElementMulticategoryFilter(list);
+            return collector
+                .WherePasses(filter)
+                .WhereElementIsNotElementType();
+        }
+
+        /// <summary>
+        /// Invokes an action for each element in the collector.
+        /// </summary>
+        /// <param name="collector">The collector to enumerate.</param>
+        /// <param name="action">The action to invoke for each element.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="collector"/> or <paramref name="action"/> is null.
+        /// </exception>
+        public static void ForEach(this FilteredElementCollector collector, Action<Element> action)
+        {
+            if (collector == null) throw new ArgumentNullException(nameof(collector));
+            if (action == null) throw new ArgumentNullException(nameof(action));
+
+            var enumerator = collector.GetEnumerator();
+            try
+            {
+                while (enumerator.MoveNext())
+                {
+                    var element = enumerator.Current;
+                    try
+                    {
+                        action(element);
+                    }
+                    finally
+                    {
+                        if (element is IDisposable disposable)
+                        {
+                            disposable.Dispose();
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                (enumerator as IDisposable)?.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Element` with `IDisposable` and tracking flag for tests
- rework `FilteredElementCollectorExtensions.ForEach` to dispose items after use
- verify elements are disposed in unit test
- add overloads to collect instances from multiple categories

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true -p:DefineConstants=REVIT2026%3BREVIT2026_OR_ABOVE%3BREVIT2025_OR_ABOVE%3BREVIT2024_OR_ABOVE`


------
https://chatgpt.com/codex/tasks/task_e_68519f8fc8e4832693815e9d699bed25