### PR TITLE
Use GitVersion for dynamic package versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: build
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore RevitExtensions.sln
+      - name: Build all versions
+        run: ./build.sh
+      - name: Test
+        run: dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true
+
+  publish:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v3
+        with:
+          versionSpec: '5.x'
+      - name: Determine version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v3
+      - name: Build packages
+        run: ./pack.sh ${{ steps.gitversion.outputs.fullSemVer }}
+      - name: Publish packages
+        run: dotnet nuget push nupkgs/**/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json

--- a/README.md
+++ b/README.md
@@ -4,8 +4,18 @@ This repository contains helper extensions for the Autodesk Revit API. The goal 
 
 ## Building packages
 
-Run `./pack.sh` to build NuGet packages for Revit versions 2019 through 2026.
-Packages will be written to the `nupkgs` directory.
+Run `./build.sh` to compile the library for all supported Revit versions.
+To produce NuGet packages run `./pack.sh`. Packages will be written to the
+`nupkgs` directory. Pass a version as the first argument to override the default
+`0.0.1`. The CI workflow uses GitVersion to calculate a semantic version and
+forwards it to the script when publishing packages.
+
+Packages use an assembly name that includes the Revit year and the package
+version. For example a package built for Revit 2025 will produce an assembly
+named `RevitExtensions.2025.0.0.1` when the version is `0.0.1`.
+Each NuGet package is published with an id that also includes the Revit year,
+such as `RevitExtensions.2024`, and the package version matches the assembly
+version (`0.0.1` by default).
 
 ## Running tests
 

--- a/RevitExtensions/RevitExtensions.csproj
+++ b/RevitExtensions/RevitExtensions.csproj
@@ -9,6 +9,12 @@
     <PackageTags>Revit;API;Extensions</PackageTags>
     <!-- Default Revit API package version; overridden during packaging -->
     <RevitApiPackageVersion>2026.0.0</RevitApiPackageVersion>
+    <!-- Default values that can be overridden when packaging -->
+    <AssemblyVersion>0.0.1</AssemblyVersion>
+    <RevitYear>2026</RevitYear>
+    <!-- Assembly name includes Revit year and assembly version -->
+    <AssemblyName>RevitExtensions.$(RevitYear).$(AssemblyVersion)</AssemblyName>
+    <Version>$(AssemblyVersion)</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseRevitApiStubs)' == 'true'">

--- a/build.sh
+++ b/build.sh
@@ -2,12 +2,6 @@
 set -e
 set -x
 
-
-OUTPUT=$(pwd)/nupkgs
-mkdir -p "$OUTPUT"
-
-assembly_version=${1:-0.0.1}
-
 for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
   if [ "$year" -ge 2025 ]; then
     tf=net8.0
@@ -26,7 +20,6 @@ for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
     2026) api_ver=2026.0.0 ;;
   esac
 
-  # build define constants
   defines="REVIT${year}"
   for y in {2019..2026}; do
     if [ "$year" -ge "$y" ]; then
@@ -50,20 +43,5 @@ for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
     -p:DefineConstants=${encoded_defs} \
     -p:RevitApiPackageVersion=${api_ver} \
     -p:UseRevitApiStubs=false \
-    -p:RevitYear=${year} \
-    -p:AssemblyVersion=${assembly_version}
-
-  dotnet msbuild RevitExtensions/RevitExtensions.csproj -t:pack \
-    -p:NoBuild=true \
-    -p:TargetFrameworks=${tf} \
-    -p:Configuration=Release \
-    -p:PackageVersion=${assembly_version} \
-    -p:PackageId=RevitExtensions.${year} \
-    -p:PackageOutputPath="$OUTPUT" \
-    -p:TargetFramework=${tf} \
-    -p:DefineConstants=${encoded_defs} \
-    -p:RevitApiPackageVersion=${api_ver} \
-    -p:UseRevitApiStubs=false \
-    -p:RevitYear=${year} \
-    -p:AssemblyVersion=${assembly_version}
+    -p:RevitYear=${year}
 done


### PR DESCRIPTION
## Summary
- pass version to `pack.sh` and document it in README
- build with real Revit API packages instead of stubs
- use GitVersion in CI to calculate semantic package versions
- build all Revit versions via new `build.sh` and split packaging logic
- fix workflow restore step

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_6851cd5aba10832681f71001c31a5ad7