### PR TITLE
Fix assembly version format during packaging

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -6,7 +6,8 @@ set -x
 OUTPUT=$(pwd)/nupkgs
 mkdir -p "$OUTPUT"
 
-assembly_version=${1:-0.0.1}
+package_version=${1:-0.0.1}
+assembly_version=${package_version//+/.}
 
 for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
   if [ "$year" -ge 2025 ]; then
@@ -57,7 +58,7 @@ for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
     -p:NoBuild=true \
     -p:TargetFrameworks=${tf} \
     -p:Configuration=Release \
-    -p:PackageVersion=${assembly_version} \
+    -p:PackageVersion=${package_version} \
     -p:PackageId=RevitExtensions.${year} \
     -p:PackageOutputPath="$OUTPUT" \
     -p:TargetFramework=${tf} \


### PR DESCRIPTION
## Summary
- sanitize assembly version when building packages
- ensure package version uses original SemVer

## Testing
- `bash pack.sh 0.1.0+10`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_6851e94a6644832690c3b1591f6ef4a7