### PR TITLE
Enable NuGet publishing from PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      GH_FEED: >
+      GH_FEED: >-
         https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,15 +20,22 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v3
+        with:
+          versionSpec: '5.x'
+      - name: Determine version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v3
       - name: Restore
         run: dotnet restore RevitExtensions.sln
       - name: Build all versions
-        run: ./build.sh
+        run: ./build.sh ${{ steps.gitversion.outputs.fullSemVer }}
       - name: Test
         run: dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true
 
   publish:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -43,5 +54,16 @@ jobs:
         uses: gittools/actions/gitversion/execute@v3
       - name: Build packages
         run: ./pack.sh ${{ steps.gitversion.outputs.fullSemVer }}
-      - name: Publish packages
-        run: dotnet nuget push nupkgs/**/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+      - name: Publish to GitHub Packages
+        run: |
+          dotnet nuget push nupkgs/**/*.nupkg \
+            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            --api-key ${{ secrets.GITHUB_TOKEN }} \
+            --skip-duplicate
+      - name: Publish to nuget.org
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          dotnet nuget push nupkgs/**/*.nupkg \
+            --source "https://api.nuget.org/v3/index.json" \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --skip-duplicate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
+---
 name: build
 
-on:
+"on":
   pull_request:
-    branches: [ master ]
+    branches: [master]
   push:
-    branches: [ master ]
+    branches: [master]
 
 permissions:
   contents: read
@@ -35,9 +36,15 @@ jobs:
         run: dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true
 
   publish:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     needs: build
     runs-on: ubuntu-latest
+    env:
+      GH_FEED: >
+        https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
     steps:
       - uses: actions/checkout@v3
         with:
@@ -57,7 +64,7 @@ jobs:
       - name: Publish to GitHub Packages
         run: |
           dotnet nuget push nupkgs/**/*.nupkg \
-            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            --source "$GH_FEED" \
             --api-key ${{ secrets.GITHUB_TOKEN }} \
             --skip-duplicate
       - name: Publish to nuget.org

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,9 @@
 set -e
 set -x
 
+package_version=${1:-0.0.1}
+assembly_version=${package_version//+/.}
+
 for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
   if [ "$year" -ge 2025 ]; then
     tf=net8.0
@@ -43,5 +46,6 @@ for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
     -p:DefineConstants=${encoded_defs} \
     -p:RevitApiPackageVersion=${api_ver} \
     -p:UseRevitApiStubs=false \
-    -p:RevitYear=${year}
+    -p:RevitYear=${year} \
+    -p:AssemblyVersion=${assembly_version}
 done

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,14 @@ set -e
 set -x
 
 package_version=${1:-0.0.1}
-assembly_version=${package_version//+/.}
+# AssemblyVersion must be numeric. Strip any pre-release tag and ensure
+# four version components.
+version_core=${package_version%%[-+]*}
+IFS='.' read -r -a parts <<< "$version_core"
+while [ ${#parts[@]} -lt 4 ]; do
+  parts+=(0)
+done
+assembly_version="${parts[0]}.${parts[1]}.${parts[2]}.${parts[3]}"
 
 for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
   if [ "$year" -ge 2025 ]; then

--- a/pack.sh
+++ b/pack.sh
@@ -7,7 +7,14 @@ OUTPUT=$(pwd)/nupkgs
 mkdir -p "$OUTPUT"
 
 package_version=${1:-0.0.1}
-assembly_version=${package_version//+/.}
+# AssemblyVersion must be numeric. Strip any pre-release tag and ensure
+# four version components.
+version_core=${package_version%%[-+]*}
+IFS='.' read -r -a parts <<< "$version_core"
+while [ ${#parts[@]} -lt 4 ]; do
+  parts+=(0)
+done
+assembly_version="${parts[0]}.${parts[1]}.${parts[2]}.${parts[3]}"
 
 for year in 2019 2020 2021 2022 2023 2024 2025 2026; do
   if [ "$year" -ge 2025 ]; then


### PR DESCRIPTION
## Summary
- allow the publish job to run on pull requests from the same repo
- grant packages write permissions in the workflow
- publish packages to GitHub on pushes and PRs
- push packages to nuget.org only when pushing to `master`
- build and pack using the semantic version from GitVersion

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true -p:DefineConstants=REVIT2026%3BREVIT2026_OR_ABOVE%3BREVIT2025_OR_ABOVE%3BREVIT2024_OR_ABOVE`
- `yamllint .github/workflows/ci.yml` *(fails: line-length, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6851ee1749188326beb63a1469a0f331