### PR TITLE
Make publish manual

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ name: build
     branches: [master]
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -36,10 +37,7 @@ jobs:
         run: dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true
 
   publish:
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     env:
@@ -68,7 +66,7 @@ jobs:
             --api-key ${{ secrets.GITHUB_TOKEN }} \
             --skip-duplicate
       - name: Publish to nuget.org
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         run: |
           dotnet nuget push nupkgs/**/*.nupkg \
             --source "https://api.nuget.org/v3/index.json" \


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` trigger
- run publish job only when manual
- update nuget.org publish condition

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`

------
https://chatgpt.com/codex/tasks/task_e_685255a983108326a7bbd47afee70b44