### PR TITLE
Make publish automatic for PR events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true
 
   publish:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- run publish job on pull_request event

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_685261b2b20083268c10ba88bf9b5a3b