### PR TITLE
Add element type collector extensions

### DIFF
--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -53,6 +53,7 @@ namespace Autodesk.Revit.DB
         public BuiltInCategory? Category { get; private set; }
         public System.Collections.Generic.IList<BuiltInCategory> Categories { get; private set; }
         public bool ExcludesElementTypes { get; private set; }
+        public bool OnlyElementTypes { get; private set; }
 
         private readonly System.Collections.Generic.List<Element> _elements = new System.Collections.Generic.List<Element>();
 
@@ -88,6 +89,14 @@ namespace Autodesk.Revit.DB
         public FilteredElementCollector WhereElementIsNotElementType()
         {
             ExcludesElementTypes = true;
+            OnlyElementTypes = false;
+            return this;
+        }
+
+        public FilteredElementCollector WhereElementIsElementType()
+        {
+            OnlyElementTypes = true;
+            ExcludesElementTypes = false;
             return this;
         }
     }

--- a/RevitExtensions.Tests/DocumentExtensionsTests.cs
+++ b/RevitExtensions.Tests/DocumentExtensionsTests.cs
@@ -18,6 +18,17 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
+        public void TypesOf_Type_ReturnsCollectorWithDocumentAndType()
+        {
+            var doc = new Document();
+            var collector = doc.TypesOf<Wall>();
+
+            Assert.Same(doc, collector.Document);
+            Assert.Equal(typeof(Wall), collector.FilterType);
+            Assert.True(collector.OnlyElementTypes);
+        }
+
+        [Fact]
         public void InstancesOf_Category_ReturnsCollectorWithDocumentAndCategory()
         {
             var doc = new Document();
@@ -26,6 +37,17 @@ namespace RevitExtensions.Tests
             Assert.Same(doc, collector.Document);
             Assert.Equal(BuiltInCategory.GenericModel, collector.Category);
             Assert.True(collector.ExcludesElementTypes);
+        }
+
+        [Fact]
+        public void TypesOf_Category_ReturnsCollectorWithDocumentAndCategory()
+        {
+            var doc = new Document();
+            var collector = doc.TypesOf(BuiltInCategory.GenericModel);
+
+            Assert.Same(doc, collector.Document);
+            Assert.Equal(BuiltInCategory.GenericModel, collector.Category);
+            Assert.True(collector.OnlyElementTypes);
         }
 
         [Fact]
@@ -38,6 +60,18 @@ namespace RevitExtensions.Tests
             Assert.Same(doc, collector.Document);
             Assert.Equal(cats, collector.Categories);
             Assert.True(collector.ExcludesElementTypes);
+        }
+
+        [Fact]
+        public void TypesOf_Categories_ReturnsCollectorWithDocumentAndCategories()
+        {
+            var doc = new Document();
+            var cats = new[] { BuiltInCategory.GenericModel, BuiltInCategory.GenericModel };
+            var collector = doc.TypesOf(cats);
+
+            Assert.Same(doc, collector.Document);
+            Assert.Equal(cats, collector.Categories);
+            Assert.True(collector.OnlyElementTypes);
         }
     }
 }

--- a/RevitExtensions.Tests/FilteredElementCollectorExtensionsTests.cs
+++ b/RevitExtensions.Tests/FilteredElementCollectorExtensionsTests.cs
@@ -38,5 +38,18 @@ namespace RevitExtensions.Tests
             Assert.Equal(cats, collector.Categories);
             Assert.True(collector.ExcludesElementTypes);
         }
+
+        [Fact]
+        public void TypesOf_MultiCategories_FiltersCollector()
+        {
+            var doc = new Document();
+            var cats = new[] { BuiltInCategory.GenericModel, BuiltInCategory.GenericModel };
+            var collector = new FilteredElementCollector(doc)
+                .TypesOf(cats);
+
+            Assert.Equal(cats, collector.Categories);
+            Assert.True(collector.OnlyElementTypes);
+        }
     }
 }
+

--- a/RevitExtensions/DocumentExtensions.cs
+++ b/RevitExtensions/DocumentExtensions.cs
@@ -24,6 +24,21 @@ namespace RevitExtensions
         }
 
         /// <summary>
+        /// Creates a collector for element types of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="document">The document to search.</param>
+        /// <returns>A filtered element collector for types of <typeparamref name="T"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> is null.</exception>
+        public static FilteredElementCollector TypesOf<T>(this Document document) where T : Element
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return new FilteredElementCollector(document)
+                .TypesOf<T>();
+        }
+
+        /// <summary>
         /// Creates a collector for elements in the specified built-in category.
         /// </summary>
         /// <param name="document">The document to search.</param>
@@ -36,6 +51,21 @@ namespace RevitExtensions
 
             return new FilteredElementCollector(document)
                 .InstancesOf(category);
+        }
+
+        /// <summary>
+        /// Creates a collector for element types in the specified built-in category.
+        /// </summary>
+        /// <param name="document">The document to search.</param>
+        /// <param name="category">The built-in category to filter by.</param>
+        /// <returns>A collector filtered by the given category.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> is null.</exception>
+        public static FilteredElementCollector TypesOf(this Document document, BuiltInCategory category)
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return new FilteredElementCollector(document)
+                .TypesOf(category);
         }
 
         /// <summary>
@@ -53,5 +83,22 @@ namespace RevitExtensions
             return new FilteredElementCollector(document)
                 .InstancesOf(categories);
         }
+
+        /// <summary>
+        /// Creates a collector for element types in the specified built-in categories.
+        /// </summary>
+        /// <param name="document">The document to search.</param>
+        /// <param name="categories">The built-in categories to filter by.</param>
+        /// <returns>A collector filtered by the given categories.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> or <paramref name="categories"/> is null.</exception>
+        public static FilteredElementCollector TypesOf(this Document document, System.Collections.Generic.IEnumerable<BuiltInCategory> categories)
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (categories == null) throw new ArgumentNullException(nameof(categories));
+
+            return new FilteredElementCollector(document)
+                .TypesOf(categories);
+        }
     }
 }
+

--- a/RevitExtensions/FilteredElementCollectorExtensions.cs
+++ b/RevitExtensions/FilteredElementCollectorExtensions.cs
@@ -25,6 +25,22 @@ namespace RevitExtensions
         }
 
         /// <summary>
+        /// Filters the collector for element types of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="collector">The collector to filter.</param>
+        /// <returns>The filtered collector.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="collector"/> is null.</exception>
+        public static FilteredElementCollector TypesOf<T>(this FilteredElementCollector collector) where T : Element
+        {
+            if (collector == null) throw new ArgumentNullException(nameof(collector));
+
+            return collector
+                .OfClass(typeof(T))
+                .WhereElementIsElementType();
+        }
+
+        /// <summary>
         /// Filters the collector for instances in the specified category.
         /// </summary>
         /// <param name="collector">The collector to filter.</param>
@@ -39,6 +55,23 @@ namespace RevitExtensions
             return collector
                 .WherePasses(filter)
                 .WhereElementIsNotElementType();
+        }
+
+        /// <summary>
+        /// Filters the collector for element types in the specified category.
+        /// </summary>
+        /// <param name="collector">The collector to filter.</param>
+        /// <param name="category">The built-in category.</param>
+        /// <returns>The filtered collector.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="collector"/> is null.</exception>
+        public static FilteredElementCollector TypesOf(this FilteredElementCollector collector, BuiltInCategory category)
+        {
+            if (collector == null) throw new ArgumentNullException(nameof(collector));
+
+            var filter = new ElementCategoryFilter(category);
+            return collector
+                .WherePasses(filter)
+                .WhereElementIsElementType();
         }
 
         /// <summary>
@@ -58,6 +91,25 @@ namespace RevitExtensions
             return collector
                 .WherePasses(filter)
                 .WhereElementIsNotElementType();
+        }
+
+        /// <summary>
+        /// Filters the collector for element types in the specified categories.
+        /// </summary>
+        /// <param name="collector">The collector to filter.</param>
+        /// <param name="categories">The built-in categories.</param>
+        /// <returns>The filtered collector.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="collector"/> or <paramref name="categories"/> is null.</exception>
+        public static FilteredElementCollector TypesOf(this FilteredElementCollector collector, System.Collections.Generic.IEnumerable<BuiltInCategory> categories)
+        {
+            if (collector == null) throw new ArgumentNullException(nameof(collector));
+            if (categories == null) throw new ArgumentNullException(nameof(categories));
+
+            var list = new System.Collections.Generic.List<BuiltInCategory>(categories);
+            var filter = new ElementMulticategoryFilter(list);
+            return collector
+                .WherePasses(filter)
+                .WhereElementIsElementType();
         }
 
         /// <summary>
@@ -99,3 +151,4 @@ namespace RevitExtensions
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- support filtering `FilteredElementCollector` for element types via `TypesOf`
- expose matching `Document.TypesOf` helpers
- update Revit API stubs for `WhereElementIsElementType`
- add unit tests covering new methods

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true -p:DefineConstants=REVIT2026%3BREVIT2026_OR_ABOVE%3BREVIT2025_OR_ABOVE%3BREVIT2024_OR_ABOVE`

------
https://chatgpt.com/codex/tasks/task_e_6853c26060bc83269bf9c645285ee4b2