### PR TITLE
Add shorter can edit helpers

### DIFF
--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -64,9 +64,23 @@ namespace Autodesk.Revit.DB
 
         public CheckoutStatus GetCheckoutStatus(ElementId elementId)
         {
-            var owner = GetElementOwner(elementId);
+            return WorksharingUtils.GetCheckoutStatus(this, elementId);
+        }
+    }
+
+    /// <summary>
+    /// Provides helper methods for worksharing related functionality.
+    /// </summary>
+    public static class WorksharingUtils
+    {
+        public static CheckoutStatus GetCheckoutStatus(Document doc, ElementId elementId)
+        {
+            if (doc == null) throw new ArgumentNullException(nameof(doc));
+            if (elementId == null) throw new ArgumentNullException(nameof(elementId));
+
+            var owner = doc.GetElementOwner(elementId);
             if (string.IsNullOrEmpty(owner)) return CheckoutStatus.NotOwned;
-            return owner == CurrentUser ? CheckoutStatus.OwnedByCurrentUser : CheckoutStatus.OwnedByOtherUser;
+            return owner == doc.CurrentUser ? CheckoutStatus.OwnedByCurrentUser : CheckoutStatus.OwnedByOtherUser;
         }
     }
 

--- a/RevitExtensions.Tests/ElementExtensionsTests.cs
+++ b/RevitExtensions.Tests/ElementExtensionsTests.cs
@@ -20,5 +20,57 @@ namespace RevitExtensions.Tests
             var element = new Element(id);
             Assert.Equal(99L, element.GetElementIdValue());
         }
+
+        [Fact]
+        public void CanEdit_NotWorkshared_ReturnsTrue()
+        {
+            var doc = new Document();
+            var element = new Element(doc, new ElementId(1));
+
+            var result = element.CanEdit(out var status);
+
+            Assert.True(result);
+            Assert.Equal(EditStatus.NotWorkshared, status);
+        }
+
+        [Fact]
+        public void CanEdit_Unowned_ReturnsEditable()
+        {
+            var doc = new Document { IsWorkshared = true, CurrentUser = "A" };
+            var element = new Element(doc, new ElementId(2));
+
+            var result = element.CanEdit(out var status);
+
+            Assert.True(result);
+            Assert.Equal(EditStatus.Editable, status);
+        }
+
+        [Fact]
+        public void CanEdit_OwnedBySelf_ReturnsOwnedByCurrentUser()
+        {
+            var doc = new Document { IsWorkshared = true, CurrentUser = "A" };
+            var id = new ElementId(3);
+            doc.SetElementOwner(id, "A");
+            var element = new Element(doc, id);
+
+            var result = element.CanEdit(out var status);
+
+            Assert.True(result);
+            Assert.Equal(EditStatus.OwnedByCurrentUser, status);
+        }
+
+        [Fact]
+        public void CanEdit_OwnedByOther_ReturnsFalse()
+        {
+            var doc = new Document { IsWorkshared = true, CurrentUser = "A" };
+            var id = new ElementId(4);
+            doc.SetElementOwner(id, "B");
+            var element = new Element(doc, id);
+
+            var result = element.CanEdit(out var status);
+
+            Assert.False(result);
+            Assert.Equal(EditStatus.OwnedByOtherUser, status);
+        }
     }
 }

--- a/RevitExtensions/EditStatus.cs
+++ b/RevitExtensions/EditStatus.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Reasons describing whether an element is available for editing.
+    /// </summary>
+    public enum EditStatus
+    {
+        /// <summary>
+        /// The element is editable.
+        /// </summary>
+        Editable,
+
+        /// <summary>
+        /// Worksharing is disabled for the document.
+        /// </summary>
+        NotWorkshared,
+
+        /// <summary>
+        /// The element is owned by the current user.
+        /// </summary>
+        OwnedByCurrentUser,
+
+        /// <summary>
+        /// The element is owned by another user.
+        /// </summary>
+        OwnedByOtherUser,
+    }
+
+    /// <summary>
+    /// Extension methods for <see cref="EditStatus"/>.
+    /// </summary>
+    public static class EditStatusExtensions
+    {
+        /// <summary>
+        /// Gets a human readable string for the given status.
+        /// </summary>
+        /// <param name="status">The status to describe.</param>
+        /// <returns>A user friendly description.</returns>
+        public static string ToFriendlyString(this EditStatus status)
+        {
+            switch (status)
+            {
+                case EditStatus.Editable:
+                    return "Editable";
+                case EditStatus.NotWorkshared:
+                    return "Not workshared";
+                case EditStatus.OwnedByCurrentUser:
+                    return "Owned by current user";
+                case EditStatus.OwnedByOtherUser:
+                    return "Owned by another user";
+                default:
+                    return status.ToString();
+            }
+        }
+    }
+}

--- a/RevitExtensions/ElementExtensions.cs
+++ b/RevitExtensions/ElementExtensions.cs
@@ -34,5 +34,50 @@ namespace RevitExtensions
             return id.IntegerValue;
 #endif
         }
+
+        /// <summary>
+        /// Determines if the element can be edited.
+        /// </summary>
+        /// <param name="element">The element to check.</param>
+        /// <returns>True if the element can be edited.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> is null.</exception>
+        public static bool CanEdit(this Element element)
+        {
+            return element.CanEdit(out _);
+        }
+
+        /// <summary>
+        /// Determines if the element can be edited.
+        /// </summary>
+        /// <param name="element">The element to check.</param>
+        /// <param name="status">Outputs the edit status.</param>
+        /// <returns>True if the element can be edited.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> is null.</exception>
+        public static bool CanEdit(this Element element, out EditStatus status)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            var document = element.Document;
+            if (document == null || !document.IsWorkshared)
+            {
+                status = EditStatus.NotWorkshared;
+                return true;
+            }
+
+            var checkout = document.GetCheckoutStatus(element.Id);
+
+            switch (checkout)
+            {
+                case CheckoutStatus.OwnedByCurrentUser:
+                    status = EditStatus.OwnedByCurrentUser;
+                    return true;
+                case CheckoutStatus.NotOwned:
+                    status = EditStatus.Editable;
+                    return true;
+                default:
+                    status = EditStatus.OwnedByOtherUser;
+                    return false;
+            }
+        }
     }
 }

--- a/RevitExtensions/ElementExtensions.cs
+++ b/RevitExtensions/ElementExtensions.cs
@@ -64,7 +64,7 @@ namespace RevitExtensions
                 return true;
             }
 
-            var checkout = document.GetCheckoutStatus(element.Id);
+            var checkout = WorksharingUtils.GetCheckoutStatus(document, element.Id);
 
             switch (checkout)
             {


### PR DESCRIPTION
## Summary
- provide stub `CheckoutStatus` enum and `Document.GetCheckoutStatus`
- rename `ElementEditAvailability` to `EditStatus`
- rename `IsAvailableForEdit` extension to `CanEdit`
- update tests for new API

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true -p:DefineConstants=REVIT2026%3BREVIT2026_OR_ABOVE%3BREVIT2025_OR_ABOVE%3BREVIT2024_OR_ABOVE`


------
https://chatgpt.com/codex/tasks/task_e_6853e09160c88326803a056b8f84cb17