### PR TITLE
Add testing info to agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+This repository provides extension methods for the Autodesk Revit API. It aligns older releases with newer ones so consumers can use a consistent, higher-level API. A core example is retrieving an element id as a `long` regardless of the Revit version.
+
+## Building
+Always compile the library across *all* supported Revit versions using [NUKE](https://nuke.build). Use the build script:
+
+```bash
+./build.sh --target BuildAll
+```
+
+This checks compilation for every Revit year defined in the build configuration. Do not run the build for only a single Revit version. The official API assemblies come from the `Revit_All_Main_Versions_API_x64` package so the code builds without needing Revit installed.
+
+## Testing
+The Revit API relies on native code and normally requires a running Revit instance. Unit tests instead reference the `RevitApiStubs` project to simulate the API. Run the tests with the stubs enabled:
+
+```bash
+dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true
+```
+
+The stubs only support the surface area covered by the tests and should not be used in production code.


### PR DESCRIPTION
## Summary
- update instructions about building across Revit versions
- add a new section describing how tests use `RevitApiStubs`

## Testing
- `./build.sh --target BuildAll` *(fails: BuildAll Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68543444db688326adc5e6225575f835