### PR TITLE
Add ParameterIdentifier helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,3 +405,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 nupkgs/
+.nuke/

--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -238,6 +238,15 @@ namespace Autodesk.Revit.DB
 
     public enum BuiltInParameter { }
 
+    public enum StorageType
+    {
+        None,
+        Integer,
+        Double,
+        String,
+        ElementId,
+    }
+
     public class Parameter : IDisposable
     {
         public BuiltInParameter? BuiltInParameter { get; }
@@ -245,11 +254,72 @@ namespace Autodesk.Revit.DB
         public Guid? Guid { get; }
         public string Name { get; }
         public bool IsDisposed { get; private set; }
+        public StorageType StorageType { get; set; }
+        public bool IsReadOnly { get; set; }
+
+        private int _intValue;
+        private double _doubleValue;
+        private string _stringValue;
+        private ElementId _elementIdValue;
 
         public Parameter(BuiltInParameter bip) => BuiltInParameter = bip;
         public Parameter(ElementId id) => Id = id;
         public Parameter(Guid guid) => Guid = guid;
         public Parameter(string name) => Name = name;
+
+        public int AsInteger() => _intValue;
+        public double AsDouble() => _doubleValue;
+        public string AsString() => _stringValue;
+        public ElementId AsElementId() => _elementIdValue;
+
+        public bool Set(int value)
+        {
+            if (IsReadOnly) return false;
+            _intValue = value;
+            StorageType = StorageType.Integer;
+            return true;
+        }
+
+        public bool Set(double value)
+        {
+            if (IsReadOnly) return false;
+            _doubleValue = value;
+            StorageType = StorageType.Double;
+            return true;
+        }
+
+        public bool Set(string value)
+        {
+            if (IsReadOnly) return false;
+            _stringValue = value;
+            StorageType = StorageType.String;
+            return true;
+        }
+
+        public bool Set(ElementId value)
+        {
+            if (IsReadOnly) return false;
+            _elementIdValue = value;
+            StorageType = StorageType.ElementId;
+            return true;
+        }
+
+        public bool SetValueString(string value) => Set(value);
+        public string AsValueString()
+        {
+            return StorageType switch
+            {
+                StorageType.Integer => _intValue.ToString(),
+                StorageType.Double => _doubleValue.ToString(),
+                StorageType.String => _stringValue,
+#if REVIT2024_OR_ABOVE
+                StorageType.ElementId => _elementIdValue?.Value.ToString(),
+#else
+                StorageType.ElementId => _elementIdValue?.IntegerValue.ToString(),
+#endif
+                _ => string.Empty,
+            };
+        }
 
         public void Dispose() => IsDisposed = true;
     }

--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -43,13 +43,56 @@ namespace Autodesk.Revit.DB
 
         public ElementId GetTypeId() => TypeId;
 
-        public Parameter get_Parameter(BuiltInParameter parameter) => new Parameter(parameter);
+        private static long GetIdValue(ElementId id)
+        {
+#if REVIT2024_OR_ABOVE
+            return id?.Value ?? 0;
+#else
+            return id?.IntegerValue ?? 0;
+#endif
+        }
 
-        public Parameter get_Parameter(ElementId id) => new Parameter(id);
+        public Parameter get_Parameter(BuiltInParameter parameter)
+        {
+            foreach (var p in Parameters)
+            {
+                if (p.BuiltInParameter == parameter)
+                    return p;
+            }
+            return null;
+        }
 
-        public Parameter get_Parameter(Guid guid) => new Parameter(guid);
+        public Parameter get_Parameter(ElementId id)
+        {
+            if (id == null) return null;
+            var value = GetIdValue(id);
+            foreach (var p in Parameters)
+            {
+                if (p.Id != null && GetIdValue(p.Id) == value)
+                    return p;
+            }
+            return null;
+        }
 
-        public Parameter LookupParameter(string name) => new Parameter(name);
+        public Parameter get_Parameter(Guid guid)
+        {
+            foreach (var p in Parameters)
+            {
+                if (p.Guid.HasValue && p.Guid.Value == guid)
+                    return p;
+            }
+            return null;
+        }
+
+        public Parameter LookupParameter(string name)
+        {
+            foreach (var p in Parameters)
+            {
+                if (p.Definition?.Name == name || p.Name == name)
+                    return p;
+            }
+            return null;
+        }
 
         /// <summary>
         /// Disposes the element. In the stubs this simply sets <see cref="IsDisposed"/>.

--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -247,12 +247,22 @@ namespace Autodesk.Revit.DB
         ElementId,
     }
 
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.Definition.
+    /// </summary>
+    public class Definition
+    {
+        public string Name { get; set; }
+    }
+
     public class Parameter : IDisposable
     {
         public BuiltInParameter? BuiltInParameter { get; }
         public ElementId Id { get; }
         public Guid? Guid { get; }
+        public Guid? GUID => Guid;
         public string Name { get; }
+        public Definition Definition { get; }
         public bool IsDisposed { get; private set; }
         public StorageType StorageType { get; set; }
         public bool IsReadOnly { get; set; }
@@ -262,10 +272,29 @@ namespace Autodesk.Revit.DB
         private string _stringValue;
         private ElementId _elementIdValue;
 
-        public Parameter(BuiltInParameter bip) => BuiltInParameter = bip;
-        public Parameter(ElementId id) => Id = id;
-        public Parameter(Guid guid) => Guid = guid;
-        public Parameter(string name) => Name = name;
+        public Parameter(BuiltInParameter bip)
+        {
+            BuiltInParameter = bip;
+            Definition = new Definition { Name = bip.ToString() };
+        }
+
+        public Parameter(ElementId id)
+        {
+            Id = id;
+            Definition = new Definition();
+        }
+
+        public Parameter(Guid guid)
+        {
+            Guid = guid;
+            Definition = new Definition();
+        }
+
+        public Parameter(string name)
+        {
+            Name = name;
+            Definition = new Definition { Name = name };
+        }
 
         public int AsInteger() => _intValue;
         public double AsDouble() => _doubleValue;

--- a/RevitApiStubs/RevitApiStubs.csproj
+++ b/RevitApiStubs/RevitApiStubs.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <ImplicitUsings>false</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project>

--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -73,7 +73,7 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
-        public void GetParameter_GuidNotFound_FallsBackToName()
+        public void LookupParameter_GuidNotFound_FallsBackToName()
         {
             var source = new Parameter(Guid.NewGuid()) { Definition = { Name = "Foo" } };
             var identifier = source.ToIdentifier();
@@ -81,14 +81,28 @@ namespace RevitExtensions.Tests
             var element = new Element(new ElementId(3));
             element.Parameters.Add(new Parameter("Foo"));
 
-            var param = element.GetParameter(identifier);
+            var param = element.LookupParameter(identifier);
 
             Assert.NotNull(param);
             Assert.Equal("Foo", param.Name);
         }
 
         [Fact]
-        public void GetParameter_IdNotFound_FallsBackToName()
+        public void GetParameter_GuidNotFound_ReturnsNull()
+        {
+            var source = new Parameter(Guid.NewGuid()) { Definition = { Name = "Foo" } };
+            var identifier = source.ToIdentifier();
+
+            var element = new Element(new ElementId(6));
+            element.Parameters.Add(new Parameter("Foo"));
+
+            var param = element.GetParameter(identifier);
+
+            Assert.Null(param);
+        }
+
+        [Fact]
+        public void LookupParameter_IdNotFound_FallsBackToName()
         {
             var source = new Parameter(new ElementId(8)) { Definition = { Name = "Bar" } };
             var identifier = source.ToIdentifier();
@@ -96,7 +110,7 @@ namespace RevitExtensions.Tests
             var element = new Element(new ElementId(4));
             element.Parameters.Add(new Parameter("Bar"));
 
-            var param = element.GetParameter(identifier);
+            var param = element.LookupParameter(identifier);
 
             Assert.NotNull(param);
             Assert.Equal("Bar", param.Name);
@@ -213,7 +227,7 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
-        public void GetParameterValue_NullValue_TriesNextParameter()
+        public void LookupParameterValue_NullValue_TriesNextParameter()
         {
             var source = new Parameter(new ElementId(11)) { Definition = { Name = "Baz" }, StorageType = StorageType.String };
             // leave value null
@@ -225,9 +239,24 @@ namespace RevitExtensions.Tests
             second.Set("value");
             element.Parameters.Add(second);
 
-            var value = element.GetParameterValue(identifier);
+            var value = element.LookupParameterValue(identifier);
 
             Assert.Equal("value", value);
+        }
+
+        [Fact]
+        public void GetParameterValue_NullValue_ReturnsNull()
+        {
+            var source = new Parameter(new ElementId(12)) { Definition = { Name = "Qux" }, StorageType = StorageType.String };
+            var identifier = source.ToIdentifier();
+
+            var element = new Element(new ElementId(6));
+            element.Parameters.Add(source);
+            element.Parameters.Add(new Parameter("Qux") { StorageType = StorageType.String });
+
+            var value = element.GetParameterValue(identifier);
+
+            Assert.Null(value);
         }
 
         [Fact]

--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -11,10 +11,12 @@ namespace RevitExtensions.Tests
         public void GetParameter_NegativeInt_UsesBuiltInParameter()
         {
             var element = new Element(new ElementId(1));
+            var expected = new Parameter((BuiltInParameter)(-5));
+            element.Parameters.Add(expected);
+
             var param = element.GetParameter(ParameterIdentifier.Parse("-5"));
 
-            Assert.NotNull(param);
-            Assert.Equal((BuiltInParameter)(-5), param.BuiltInParameter);
+            Assert.Same(expected, param);
         }
 
         [Fact]
@@ -45,10 +47,12 @@ namespace RevitExtensions.Tests
         public void GetParameter_Name_UsesLookup()
         {
             var element = new Element(new ElementId(1));
+            var expected = new Parameter("Foo");
+            element.Parameters.Add(expected);
+
             var param = element.GetParameter(ParameterIdentifier.Parse("Foo"));
 
-            Assert.NotNull(param);
-            Assert.Equal("Foo", param.Name);
+            Assert.Same(expected, param);
         }
 
         [Fact]

--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -11,7 +11,7 @@ namespace RevitExtensions.Tests
         public void GetParameter_NegativeInt_UsesBuiltInParameter()
         {
             var element = new Element(new ElementId(1));
-            var param = element.GetParameter("-5");
+            var param = element.GetParameter(ParameterIdentifier.Parse("-5"));
 
             Assert.NotNull(param);
             Assert.Equal((BuiltInParameter)(-5), param.BuiltInParameter);
@@ -22,7 +22,7 @@ namespace RevitExtensions.Tests
         {
             var element = new Element(new ElementId(1));
             element.Parameters.Add(new Parameter(new ElementId(7)));
-            var param = element.GetParameter("7");
+            var param = element.GetParameter(ParameterIdentifier.Parse("7"));
 
             Assert.NotNull(param);
             Assert.Equal(7L, param.Id.GetElementIdValue());
@@ -33,7 +33,7 @@ namespace RevitExtensions.Tests
         {
             var element = new Element(new ElementId(1));
             var guid = Guid.NewGuid();
-            var param = element.GetParameter(guid.ToString());
+            var param = element.GetParameter(ParameterIdentifier.Parse(guid.ToString()));
 
             Assert.NotNull(param);
             Assert.Equal(guid, param.Guid);
@@ -43,7 +43,7 @@ namespace RevitExtensions.Tests
         public void GetParameter_Name_UsesLookup()
         {
             var element = new Element(new ElementId(1));
-            var param = element.GetParameter("Foo");
+            var param = element.GetParameter(ParameterIdentifier.Parse("Foo"));
 
             Assert.NotNull(param);
             Assert.Equal("Foo", param.Name);
@@ -59,7 +59,7 @@ namespace RevitExtensions.Tests
 
             var element = new Element(doc, new ElementId(2)) { TypeId = new ElementId(20) };
 
-            var param = element.GetParameter("9");
+            var param = element.GetParameter(ParameterIdentifier.Parse("9"));
 
             Assert.NotNull(param);
             Assert.Equal(9L, param.Id.GetElementIdValue());
@@ -85,7 +85,7 @@ namespace RevitExtensions.Tests
             parameter.Set(42);
             element.Parameters.Add(parameter);
 
-            var value = element.GetParameterValue("5");
+            var value = element.GetParameterValue(ParameterIdentifier.Parse("5"));
 
             Assert.Equal(42, value);
         }
@@ -109,7 +109,7 @@ namespace RevitExtensions.Tests
             parameter.Set(new ElementId(7));
             element.Parameters.Add(parameter);
 
-            var value = element.GetParameterValue<long>("7");
+            var value = element.GetParameterValue<long>(ParameterIdentifier.Parse("7"));
 
             Assert.Equal(7L, value);
         }
@@ -151,7 +151,7 @@ namespace RevitExtensions.Tests
             var parameter = new Parameter(new ElementId(10)) { StorageType = StorageType.Integer };
             element.Parameters.Add(parameter);
 
-            element.SetParameterValue("10", 5);
+            element.SetParameterValue(ParameterIdentifier.Parse("10"), 5);
 
             Assert.Equal(5, parameter.AsInteger());
         }
@@ -161,7 +161,7 @@ namespace RevitExtensions.Tests
         {
             var element = new Element(new ElementId(1));
 
-            var result = element.TrySetParameterValue("42", 1, out var reason);
+            var result = element.TrySetParameterValue(ParameterIdentifier.Parse("42"), 1, out var reason);
 
             Assert.False(result);
             Assert.Equal("Parameter not found.", reason);
@@ -172,7 +172,7 @@ namespace RevitExtensions.Tests
         {
             var element = new Element(new ElementId(1));
 
-            var ex = Assert.Throws<InvalidOperationException>(() => element.SetParameterValue("99", 2));
+            var ex = Assert.Throws<InvalidOperationException>(() => element.SetParameterValue(ParameterIdentifier.Parse("99"), 2));
             Assert.Equal("Parameter not found.", ex.Message);
         }
     }

--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -229,5 +229,54 @@ namespace RevitExtensions.Tests
 
             Assert.Equal("value", value);
         }
+
+        [Fact]
+        public void SetParameterValue_BoolToInteger_WritesZeroOrOne()
+        {
+            var parameter = new Parameter("B") { StorageType = StorageType.Integer };
+
+            parameter.SetParameterValue(true);
+
+            Assert.Equal(1, parameter.AsInteger());
+
+            parameter.SetParameterValue(false);
+
+            Assert.Equal(0, parameter.AsInteger());
+        }
+
+        [Fact]
+        public void GetParameterValue_BoolFromInteger_ParsesBool()
+        {
+            var parameter = new Parameter("C") { StorageType = StorageType.Integer };
+            parameter.Set(1);
+
+            var value = parameter.GetParameterValue<bool>();
+
+            Assert.True(value);
+        }
+
+        [Fact]
+        public void SetParameterValue_DateTimeToString_WritesIso()
+        {
+            var dt = new DateTime(2024, 6, 20, 12, 0, 0, DateTimeKind.Utc);
+            var parameter = new Parameter("D") { StorageType = StorageType.String };
+
+            parameter.SetParameterValue(dt);
+
+            Assert.Equal(dt.ToString("o"), parameter.AsString());
+        }
+
+        [Fact]
+        public void GetParameterValue_DateTimeFromInteger_ParsesUnixSeconds()
+        {
+            var dt = new DateTime(2024, 6, 20, 12, 0, 0, DateTimeKind.Utc);
+            var seconds = (int)new DateTimeOffset(dt).ToUnixTimeSeconds();
+            var parameter = new Parameter("E") { StorageType = StorageType.Integer };
+            parameter.Set(seconds);
+
+            var value = parameter.GetParameterValue<DateTime>();
+
+            Assert.Equal(dt, value);
+        }
     }
 }

--- a/RevitExtensions.Tests/ParameterIdentifierTests.cs
+++ b/RevitExtensions.Tests/ParameterIdentifierTests.cs
@@ -58,45 +58,45 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
-        public void FromParameter_Guid_ReturnsIdentifierWithGuid()
+        public void ToIdentifier_Guid_ReturnsIdentifierWithGuid()
         {
             var guid = Guid.NewGuid();
             var parameter = new Parameter(guid);
 
-            var id = ParameterIdentifier.FromParameter(parameter);
+            var id = parameter.ToIdentifier();
 
             Assert.Equal(guid, id.Guid);
             Assert.Equal(guid.ToString(), parameter.ToIdentifier().ToStableRepresentation());
         }
 
         [Fact]
-        public void FromParameter_BuiltInParameter_ReturnsIdentifier()
+        public void ToIdentifier_BuiltInParameter_ReturnsIdentifier()
         {
             var parameter = new Parameter((BuiltInParameter)(-10));
 
-            var id = ParameterIdentifier.FromParameter(parameter);
+            var id = parameter.ToIdentifier();
 
             Assert.Equal((BuiltInParameter)(-10), id.BuiltInParameter);
             Assert.Equal("-10", parameter.ToIdentifier().ToStableRepresentation());
         }
 
         [Fact]
-        public void FromParameter_Name_ReturnsIdentifier()
+        public void ToIdentifier_Name_ReturnsIdentifier()
         {
             var parameter = new Parameter("Foo");
 
-            var id = ParameterIdentifier.FromParameter(parameter);
+            var id = parameter.ToIdentifier();
 
             Assert.Equal("Foo", id.Name);
             Assert.Equal("Foo", parameter.ToIdentifier().ToStableRepresentation());
         }
 
         [Fact]
-        public void FromParameter_Id_ReturnsIdentifier()
+        public void ToIdentifier_Id_ReturnsIdentifier()
         {
             var parameter = new Parameter(new ElementId(5));
 
-            var id = ParameterIdentifier.FromParameter(parameter);
+            var id = parameter.ToIdentifier();
 
             Assert.Equal(5L, id.Id);
             Assert.Equal("5", parameter.ToIdentifier().ToStableRepresentation());

--- a/RevitExtensions.Tests/ParameterIdentifierTests.cs
+++ b/RevitExtensions.Tests/ParameterIdentifierTests.cs
@@ -77,6 +77,7 @@ namespace RevitExtensions.Tests
             var id = parameter.ToIdentifier();
 
             Assert.Equal((BuiltInParameter)(-10), id.BuiltInParameter);
+            Assert.Equal(parameter.Definition.Name, id.Name);
             Assert.Equal("-10", parameter.ToIdentifier().ToStableRepresentation());
         }
 
@@ -100,6 +101,19 @@ namespace RevitExtensions.Tests
 
             Assert.Equal(5L, id.Id);
             Assert.Equal("5", parameter.ToIdentifier().ToStableRepresentation());
+        }
+
+        [Fact]
+        public void ToIdentifier_GuidWithName_IncludesName()
+        {
+            var guid = Guid.NewGuid();
+            var parameter = new Parameter(guid);
+            parameter.Definition.Name = "Foo";
+
+            var id = parameter.ToIdentifier();
+
+            Assert.Equal(guid, id.Guid);
+            Assert.Equal("Foo", id.Name);
         }
     }
 }

--- a/RevitExtensions.Tests/ParameterIdentifierTests.cs
+++ b/RevitExtensions.Tests/ParameterIdentifierTests.cs
@@ -1,0 +1,60 @@
+using System;
+using Autodesk.Revit.DB;
+using RevitExtensions;
+using Xunit;
+
+namespace RevitExtensions.Tests
+{
+    public class ParameterIdentifierTests
+    {
+        [Fact]
+        public void Parse_GuidString_SetsGuid()
+        {
+            var guid = Guid.NewGuid().ToString();
+
+            var id = ParameterIdentifier.Parse(guid);
+
+            Assert.Equal(Guid.Parse(guid), id.Guid);
+            Assert.Null(id.BuiltInParameter);
+            Assert.Null(id.Name);
+            Assert.Null(id.Id);
+            Assert.Equal(guid, id.ToStableRepresentation());
+        }
+
+        [Fact]
+        public void Parse_NegativeInt_SetsBuiltInParameter()
+        {
+            var id = ParameterIdentifier.Parse("-42");
+
+            Assert.Equal((BuiltInParameter)(-42), id.BuiltInParameter);
+            Assert.Null(id.Guid);
+            Assert.Null(id.Name);
+            Assert.Null(id.Id);
+            Assert.Equal("-42", id.ToStableRepresentation());
+        }
+
+        [Fact]
+        public void Parse_PositiveInt_SetsId()
+        {
+            var id = ParameterIdentifier.Parse("15");
+
+            Assert.Equal(15L, id.Id);
+            Assert.Null(id.Guid);
+            Assert.Null(id.BuiltInParameter);
+            Assert.Null(id.Name);
+            Assert.Equal("15", id.ToStableRepresentation());
+        }
+
+        [Fact]
+        public void Parse_Name_SetsName()
+        {
+            var id = ParameterIdentifier.Parse("Foo");
+
+            Assert.Equal("Foo", id.Name);
+            Assert.Null(id.Guid);
+            Assert.Null(id.BuiltInParameter);
+            Assert.Null(id.Id);
+            Assert.Equal("Foo", id.ToStableRepresentation());
+        }
+    }
+}

--- a/RevitExtensions.Tests/ParameterIdentifierTests.cs
+++ b/RevitExtensions.Tests/ParameterIdentifierTests.cs
@@ -56,5 +56,50 @@ namespace RevitExtensions.Tests
             Assert.Null(id.Id);
             Assert.Equal("Foo", id.ToStableRepresentation());
         }
+
+        [Fact]
+        public void FromParameter_Guid_ReturnsIdentifierWithGuid()
+        {
+            var guid = Guid.NewGuid();
+            var parameter = new Parameter(guid);
+
+            var id = ParameterIdentifier.FromParameter(parameter);
+
+            Assert.Equal(guid, id.Guid);
+            Assert.Equal(guid.ToString(), parameter.ToIdentifier().ToStableRepresentation());
+        }
+
+        [Fact]
+        public void FromParameter_BuiltInParameter_ReturnsIdentifier()
+        {
+            var parameter = new Parameter((BuiltInParameter)(-10));
+
+            var id = ParameterIdentifier.FromParameter(parameter);
+
+            Assert.Equal((BuiltInParameter)(-10), id.BuiltInParameter);
+            Assert.Equal("-10", parameter.ToIdentifier().ToStableRepresentation());
+        }
+
+        [Fact]
+        public void FromParameter_Name_ReturnsIdentifier()
+        {
+            var parameter = new Parameter("Foo");
+
+            var id = ParameterIdentifier.FromParameter(parameter);
+
+            Assert.Equal("Foo", id.Name);
+            Assert.Equal("Foo", parameter.ToIdentifier().ToStableRepresentation());
+        }
+
+        [Fact]
+        public void FromParameter_Id_ReturnsIdentifier()
+        {
+            var parameter = new Parameter(new ElementId(5));
+
+            var id = ParameterIdentifier.FromParameter(parameter);
+
+            Assert.Equal(5L, id.Id);
+            Assert.Equal("5", parameter.ToIdentifier().ToStableRepresentation());
+        }
     }
 }

--- a/RevitExtensions/CustomConvert.cs
+++ b/RevitExtensions/CustomConvert.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Globalization;
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Provides helper conversions for parameter values.
+    /// </summary>
+    internal static class CustomConvert
+    {
+        public static object ChangeType(object value, Type targetType)
+        {
+            if (value == null) return null;
+            if (targetType.IsInstanceOfType(value)) return value;
+
+            if (targetType == typeof(bool) || targetType == typeof(bool?))
+                return ToBoolean(value);
+
+            if (targetType == typeof(DateTime) || targetType == typeof(DateTime?))
+                return ToDateTime(value);
+
+            return Convert.ChangeType(value, Nullable.GetUnderlyingType(targetType) ?? targetType);
+        }
+
+        public static bool ToBoolean(object value)
+        {
+            return value switch
+            {
+                bool b => b,
+                int i => i != 0,
+                long l => l != 0,
+                string s => bool.Parse(s),
+                _ => Convert.ToBoolean(value)
+            };
+        }
+
+        public static DateTime ToDateTime(object value)
+        {
+            return value switch
+            {
+                DateTime dt => dt,
+                int i => DateTimeOffset.FromUnixTimeSeconds(i).UtcDateTime,
+                long l => DateTimeOffset.FromUnixTimeSeconds(l).UtcDateTime,
+                double d => DateTime.FromOADate(d),
+                string s => DateTime.Parse(s, null, DateTimeStyles.RoundtripKind),
+                _ => (DateTime)Convert.ChangeType(value, typeof(DateTime))
+            };
+        }
+
+        public static bool TryToDouble(object value, out double result)
+        {
+            result = default;
+            switch (value)
+            {
+                case double d:
+                    result = d; return true;
+                case bool b:
+                    result = b ? 1 : 0; return true;
+                case DateTime dt:
+                    result = dt.ToOADate(); return true;
+                case string s:
+                    if (double.TryParse(s, out result)) return true;
+                    if (bool.TryParse(s, out var sb)) { result = sb ? 1 : 0; return true; }
+                    if (DateTime.TryParse(s, null, DateTimeStyles.RoundtripKind, out var sd)) { result = sd.ToOADate(); return true; }
+                    return false;
+                default:
+                    if (value is IConvertible conv)
+                    {
+                        try { result = Convert.ToDouble(conv); return true; }
+                        catch { }
+                    }
+                    return false;
+            }
+        }
+
+        public static bool TryToInt32(object value, out int result)
+        {
+            result = default;
+            switch (value)
+            {
+                case int i:
+                    result = i; return true;
+                case bool b:
+                    result = b ? 1 : 0; return true;
+                case DateTime dt:
+                    result = (int)new DateTimeOffset(dt).ToUnixTimeSeconds(); return true;
+                case string s:
+                    if (int.TryParse(s, out result)) return true;
+                    if (bool.TryParse(s, out var sb)) { result = sb ? 1 : 0; return true; }
+                    if (DateTime.TryParse(s, null, DateTimeStyles.RoundtripKind, out var sd)) { result = (int)new DateTimeOffset(sd).ToUnixTimeSeconds(); return true; }
+                    return false;
+                default:
+                    if (value is IConvertible conv)
+                    {
+                        try { result = Convert.ToInt32(conv); return true; }
+                        catch { }
+                    }
+                    return false;
+            }
+        }
+
+        public static bool TryToElementId(object value, out ElementId id)
+        {
+            id = null;
+            switch (value)
+            {
+                case ElementId e:
+                    id = e; return true;
+                case int i:
+                    id = new ElementId(i); return true;
+                case long l:
+                    id = new ElementId((int)l); return true;
+                case string s when int.TryParse(s, out var vi):
+                    id = new ElementId(vi); return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static string ToString(object value)
+        {
+            return value switch
+            {
+                DateTime dt => dt.ToString("o"),
+                ElementId eid => eid.GetElementIdValue().ToString(),
+                _ => value?.ToString()
+            };
+        }
+    }
+}

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -263,5 +263,16 @@ namespace RevitExtensions
 
             return parameter.TrySetParameterValue(value, out reason);
         }
+
+        /// <summary>
+        /// Creates a <see cref="ParameterIdentifier"/> for the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>A <see cref="ParameterIdentifier"/> identifying the parameter.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        public static ParameterIdentifier ToIdentifier(this Parameter parameter)
+        {
+            return ParameterIdentifier.FromParameter(parameter);
+        }
     }
 }

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -72,5 +72,196 @@ namespace RevitExtensions
             using var typeElement = element.GetElementType();
             return typeElement?.LookupParameter(identifier);
         }
+
+        /// <summary>
+        /// Retrieves the value stored in the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <typeparam name="T">The desired return type.</typeparam>
+        /// <returns>The parameter value or null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        public static object GetParameterValue(this Parameter parameter)
+        {
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+
+            return parameter.StorageType switch
+            {
+                StorageType.Double => (object)parameter.AsDouble(),
+                StorageType.Integer => parameter.AsInteger(),
+                StorageType.String => parameter.AsString(),
+                StorageType.ElementId => parameter.AsElementId()?.GetElementIdValue(),
+                _ => null,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves the value stored in the parameter and converts it to the specified type.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <typeparam name="T">The desired return type.</typeparam>
+        /// <returns>The converted value or default if the parameter value is null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        public static T GetParameterValue<T>(this Parameter parameter)
+        {
+            var value = parameter.GetParameterValue();
+            if (value == null) return default;
+
+            if (value is T t) return t;
+
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+
+        /// <summary>
+        /// Retrieves the value of the parameter identified on the element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier string.</param>
+        /// <returns>The parameter value or null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static object GetParameterValue(this Element element, string identifier)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            using var parameter = element.GetParameter(identifier);
+            return parameter?.GetParameterValue();
+        }
+
+        /// <summary>
+        /// Retrieves the value of the parameter identified on the element and converts it to the specified type.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier string.</param>
+        /// <typeparam name="T">The desired return type.</typeparam>
+        /// <returns>The converted value or default if the parameter is not found or has a null value.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static T GetParameterValue<T>(this Element element, string identifier)
+        {
+            var value = element.GetParameterValue(identifier);
+            if (value == null) return default;
+
+            if (value is T t) return t;
+
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <param name="value">The value to set.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when setting the value fails.</exception>
+        public static void SetParameterValue(this Parameter parameter, object value)
+        {
+            if (!parameter.TrySetParameterValue(value, out var reason))
+                throw new InvalidOperationException(reason);
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <param name="value">The value to set.</param>
+        /// <param name="reason">Outputs the failure reason.</param>
+        /// <returns>True if successful.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        public static bool TrySetParameterValue(this Parameter parameter, object value, out string reason)
+        {
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+
+            reason = null;
+
+            if (parameter.IsReadOnly)
+            {
+                reason = "Parameter is read-only.";
+                return false;
+            }
+
+            bool result;
+            switch (parameter.StorageType)
+            {
+                case StorageType.Double:
+                    if (value is double d)
+                        result = parameter.Set(d);
+                    else
+                    {
+                        reason = "Value must be a double.";
+                        return false;
+                    }
+                    break;
+                case StorageType.Integer:
+                    if (value is int i)
+                        result = parameter.Set(i);
+                    else
+                    {
+                        reason = "Value must be an integer.";
+                        return false;
+                    }
+                    break;
+                case StorageType.String:
+                    result = parameter.Set(value?.ToString());
+                    break;
+                case StorageType.ElementId:
+                    if (value is ElementId id)
+                    {
+                        result = parameter.Set(id);
+                    }
+                    else
+                    {
+                        reason = "Value must be an ElementId.";
+                        return false;
+                    }
+                    break;
+                default:
+                    reason = "Unsupported storage type.";
+                    return false;
+            }
+
+            if (!result)
+            {
+                reason = "Parameter set failed.";
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter identified on the element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier string.</param>
+        /// <param name="value">The value to set.</param>
+        /// <returns>True if successful.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static void SetParameterValue(this Element element, string identifier, object value)
+        {
+            if (!element.TrySetParameterValue(identifier, value, out var reason))
+                throw new InvalidOperationException(reason);
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter identified on the element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier string.</param>
+        /// <param name="value">The value to set.</param>
+        /// <param name="reason">Outputs the failure reason.</param>
+        /// <returns>True if successful.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static bool TrySetParameterValue(this Element element, string identifier, object value, out string reason)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            using var parameter = element.GetParameter(identifier);
+            if (parameter == null)
+            {
+                reason = "Parameter not found.";
+                return false;
+            }
+
+            return parameter.TrySetParameterValue(value, out reason);
+        }
     }
 }

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Autodesk.Revit.DB;
+using System.Globalization;
 
 namespace RevitExtensions
 {
@@ -122,7 +123,35 @@ namespace RevitExtensions
 
             if (value is T t) return t;
 
-            return (T)Convert.ChangeType(value, typeof(T));
+            var target = typeof(T);
+
+            if (target == typeof(bool) || target == typeof(bool?))
+            {
+                bool b = value switch
+                {
+                    int i => i != 0,
+                    long l => l != 0,
+                    string s => bool.Parse(s),
+                    bool bv => bv,
+                    _ => Convert.ToBoolean(value)
+                };
+                return (T)(object)b;
+            }
+
+            if (target == typeof(DateTime) || target == typeof(DateTime?))
+            {
+                DateTime dt = value switch
+                {
+                    int i => DateTimeOffset.FromUnixTimeSeconds(i).UtcDateTime,
+                    long l => DateTimeOffset.FromUnixTimeSeconds(l).UtcDateTime,
+                    string s => DateTime.Parse(s, null, System.Globalization.DateTimeStyles.RoundtripKind),
+                    double d => DateTime.FromOADate(d),
+                    _ => (DateTime)Convert.ChangeType(value, typeof(DateTime))
+                };
+                return (T)(object)dt;
+            }
+
+            return (T)Convert.ChangeType(value, target);
         }
 
         /// <summary>
@@ -203,7 +232,35 @@ namespace RevitExtensions
 
             if (value is T t) return t;
 
-            return (T)Convert.ChangeType(value, typeof(T));
+            var target = typeof(T);
+
+            if (target == typeof(bool) || target == typeof(bool?))
+            {
+                bool b = value switch
+                {
+                    int i => i != 0,
+                    long l => l != 0,
+                    string s => bool.Parse(s),
+                    bool bv => bv,
+                    _ => Convert.ToBoolean(value)
+                };
+                return (T)(object)b;
+            }
+
+            if (target == typeof(DateTime) || target == typeof(DateTime?))
+            {
+                DateTime dt = value switch
+                {
+                    int i => DateTimeOffset.FromUnixTimeSeconds(i).UtcDateTime,
+                    long l => DateTimeOffset.FromUnixTimeSeconds(l).UtcDateTime,
+                    string s => DateTime.Parse(s, null, System.Globalization.DateTimeStyles.RoundtripKind),
+                    double d => DateTime.FromOADate(d),
+                    _ => (DateTime)Convert.ChangeType(value, typeof(DateTime))
+                };
+                return (T)(object)dt;
+            }
+
+            return (T)Convert.ChangeType(value, target);
         }
 
         /// <summary>
@@ -221,7 +278,35 @@ namespace RevitExtensions
 
             if (value is T t) return t;
 
-            return (T)Convert.ChangeType(value, typeof(T));
+            var target = typeof(T);
+
+            if (target == typeof(bool) || target == typeof(bool?))
+            {
+                bool b = value switch
+                {
+                    int i => i != 0,
+                    long l => l != 0,
+                    string s => bool.Parse(s),
+                    bool bv => bv,
+                    _ => Convert.ToBoolean(value)
+                };
+                return (T)(object)b;
+            }
+
+            if (target == typeof(DateTime) || target == typeof(DateTime?))
+            {
+                DateTime dt = value switch
+                {
+                    int i => DateTimeOffset.FromUnixTimeSeconds(i).UtcDateTime,
+                    long l => DateTimeOffset.FromUnixTimeSeconds(l).UtcDateTime,
+                    string s => DateTime.Parse(s, null, System.Globalization.DateTimeStyles.RoundtripKind),
+                    double d => DateTime.FromOADate(d),
+                    _ => (DateTime)Convert.ChangeType(value, typeof(DateTime))
+                };
+                return (T)(object)dt;
+            }
+
+            return (T)Convert.ChangeType(value, target);
         }
 
         /// <summary>
@@ -261,48 +346,75 @@ namespace RevitExtensions
             switch (parameter.StorageType)
             {
                 case StorageType.Double:
-                    if (value is double d)
+                    double d;
+                    if (value is double dd) d = dd;
+                    else if (value is bool b) d = b ? 1 : 0;
+                    else if (value is DateTime dt) d = dt.ToOADate();
+                    else if (value is string s)
                     {
-                        if (parameter.AsDouble() == d) return true;
-                        result = parameter.Set(d);
+                        if (!double.TryParse(s, out d))
+                        {
+                            if (bool.TryParse(s, out var bs)) d = bs ? 1 : 0;
+                            else if (DateTime.TryParse(s, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dts)) d = dts.ToOADate();
+                            else { reason = "Value must be a number."; return false; }
+                        }
                     }
-                    else
+                    else if (value is IConvertible)
                     {
-                        reason = "Value must be a double.";
-                        return false;
+                        try { d = Convert.ToDouble(value); }
+                        catch { reason = "Value must be a number."; return false; }
                     }
+                    else { reason = "Value must be a number."; return false; }
+
+                    if (parameter.AsDouble() == d) return true;
+                    result = parameter.Set(d);
                     break;
                 case StorageType.Integer:
-                    if (value is int i)
+                    int i;
+                    if (value is int ii) i = ii;
+                    else if (value is bool b2) i = b2 ? 1 : 0;
+                    else if (value is DateTime dt2) i = (int)new DateTimeOffset(dt2).ToUnixTimeSeconds();
+                    else if (value is string s2)
                     {
-                        if (parameter.AsInteger() == i) return true;
-                        result = parameter.Set(i);
+                        if (!int.TryParse(s2, out i))
+                        {
+                            if (bool.TryParse(s2, out var sb)) i = sb ? 1 : 0;
+                            else if (DateTime.TryParse(s2, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dtp)) i = (int)new DateTimeOffset(dtp).ToUnixTimeSeconds();
+                            else { reason = "Value must be an integer."; return false; }
+                        }
                     }
-                    else
+                    else if (value is IConvertible)
                     {
-                        reason = "Value must be an integer.";
-                        return false;
+                        try { i = Convert.ToInt32(value); }
+                        catch { reason = "Value must be an integer."; return false; }
                     }
+                    else { reason = "Value must be an integer."; return false; }
+
+                    if (parameter.AsInteger() == i) return true;
+                    result = parameter.Set(i);
                     break;
                 case StorageType.String:
-                    var str = value?.ToString();
+                    string str;
+                    if (value is DateTime dt3) str = dt3.ToString("o");
+                    else if (value is ElementId id1) str = id1.GetElementIdValue().ToString();
+                    else str = value?.ToString();
+
                     if (string.Equals(parameter.AsString(), str)) return true;
                     result = parameter.Set(str);
                     break;
                 case StorageType.ElementId:
-                    if (value is ElementId id)
-                    {
-                        var current = parameter.AsElementId();
-                        if ((current == null && id == null) ||
-                            (current != null && current.GetElementIdValue() == id.GetElementIdValue()))
-                            return true;
-                        result = parameter.Set(id);
-                    }
-                    else
-                    {
-                        reason = "Value must be an ElementId.";
-                        return false;
-                    }
+                    ElementId id;
+                    if (value is ElementId eid) id = eid;
+                    else if (value is int i3) id = new ElementId(i3);
+                    else if (value is long l3) id = new ElementId((int)l3);
+                    else if (value is string s3 && int.TryParse(s3, out var idInt)) id = new ElementId(idInt);
+                    else { reason = "Value must be an ElementId."; return false; }
+
+                    var current = parameter.AsElementId();
+                    if ((current == null && id == null) ||
+                        (current != null && current.GetElementIdValue() == id.GetElementIdValue()))
+                        return true;
+                    result = parameter.Set(id);
                     break;
                 default:
                     reason = "Unsupported storage type.";

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -262,7 +262,10 @@ namespace RevitExtensions
             {
                 case StorageType.Double:
                     if (value is double d)
+                    {
+                        if (parameter.AsDouble() == d) return true;
                         result = parameter.Set(d);
+                    }
                     else
                     {
                         reason = "Value must be a double.";
@@ -271,7 +274,10 @@ namespace RevitExtensions
                     break;
                 case StorageType.Integer:
                     if (value is int i)
+                    {
+                        if (parameter.AsInteger() == i) return true;
                         result = parameter.Set(i);
+                    }
                     else
                     {
                         reason = "Value must be an integer.";
@@ -279,11 +285,17 @@ namespace RevitExtensions
                     }
                     break;
                 case StorageType.String:
-                    result = parameter.Set(value?.ToString());
+                    var str = value?.ToString();
+                    if (string.Equals(parameter.AsString(), str)) return true;
+                    result = parameter.Set(str);
                     break;
                 case StorageType.ElementId:
                     if (value is ElementId id)
                     {
+                        var current = parameter.AsElementId();
+                        if ((current == null && id == null) ||
+                            (current != null && current.GetElementIdValue() == id.GetElementIdValue()))
+                            return true;
                         result = parameter.Set(id);
                     }
                     else

--- a/RevitExtensions/ParameterIdentifier.cs
+++ b/RevitExtensions/ParameterIdentifier.cs
@@ -68,6 +68,57 @@ namespace RevitExtensions
         }
 
         /// <summary>
+        /// Creates a <see cref="ParameterIdentifier"/> from a Revit <see cref="Parameter"/>.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>A new <see cref="ParameterIdentifier"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        public static ParameterIdentifier FromParameter(Parameter parameter)
+        {
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+
+            var identifier = new ParameterIdentifier();
+
+            var guid = TryGetGuid(parameter);
+            if (guid.HasValue)
+            {
+                identifier.Guid = guid.Value;
+                return identifier;
+            }
+
+            var bipProp = parameter.GetType().GetProperty("BuiltInParameter");
+            if (bipProp != null)
+            {
+                var bipValue = bipProp.GetValue(parameter);
+                if (bipValue is BuiltInParameter bip)
+                {
+                    identifier.BuiltInParameter = bip;
+                    return identifier;
+                }
+            }
+
+            if (parameter.Id != null)
+            {
+                var intValue = (int)parameter.Id.GetElementIdValue();
+                if (intValue < 0)
+                {
+                    identifier.BuiltInParameter = (BuiltInParameter)intValue;
+                    return identifier;
+                }
+
+                identifier.Id = parameter.Id.GetElementIdValue();
+            }
+
+            if (!string.IsNullOrEmpty(parameter.Definition?.Name))
+            {
+                identifier.Name = parameter.Definition.Name;
+                return identifier;
+            }
+
+            return identifier;
+        }
+
+        /// <summary>
         /// Returns the most stable string representation.
         /// </summary>
         /// <returns>The stable representation string.</returns>
@@ -86,6 +137,27 @@ namespace RevitExtensions
                 return this.Id.Value.ToString();
 
             return string.Empty;
+        }
+
+        private static Guid? TryGetGuid(Parameter parameter)
+        {
+            var prop = parameter.GetType().GetProperty("GUID") ?? parameter.GetType().GetProperty("Guid");
+            if (prop == null) return null;
+            var value = prop.GetValue(parameter);
+            if (value == null) return null;
+            if (value is System.Guid g)
+            {
+                if (g == System.Guid.Empty) return null;
+                return g;
+            }
+            var type = value.GetType();
+            if (type.FullName == "System.Nullable`1[System.Guid]")
+            {
+                var ng = (System.Nullable<System.Guid>)value;
+                if (ng.HasValue && ng.Value != System.Guid.Empty) return ng.Value;
+                return null;
+            }
+            return null;
         }
     }
 }

--- a/RevitExtensions/ParameterIdentifier.cs
+++ b/RevitExtensions/ParameterIdentifier.cs
@@ -1,0 +1,91 @@
+using System;
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Represents a parameter identifier that can be expressed as a built-in parameter,
+    /// a shared parameter guid, a name, or an element id.
+    /// </summary>
+    public class ParameterIdentifier
+    {
+        /// <summary>
+        /// Gets the built-in parameter value if the identifier represents one.
+        /// </summary>
+        public BuiltInParameter? BuiltInParameter { get; private set; }
+
+        /// <summary>
+        /// Gets the shared parameter guid if the identifier represents one.
+        /// </summary>
+        public Guid? Guid { get; private set; }
+
+        /// <summary>
+        /// Gets the parameter name if the identifier represents one.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets the element id value if the identifier represents one.
+        /// </summary>
+        public long? Id { get; private set; }
+
+        private ParameterIdentifier() { }
+
+        /// <summary>
+        /// Parses a parameter identifier from a string.
+        /// </summary>
+        /// <param name="value">The identifier string.</param>
+        /// <returns>A <see cref="ParameterIdentifier"/> instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/> is null.</exception>
+        public static ParameterIdentifier Parse(string value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+
+            var identifier = new ParameterIdentifier();
+
+            if (System.Guid.TryParse(value, out var guid))
+            {
+                identifier.Guid = guid;
+                return identifier;
+            }
+
+            if (int.TryParse(value, out var intValue))
+            {
+                if (intValue < 0)
+                {
+                    identifier.BuiltInParameter = (BuiltInParameter)intValue;
+                }
+                else
+                {
+                    identifier.Id = intValue;
+                }
+
+                return identifier;
+            }
+
+            identifier.Name = value;
+            return identifier;
+        }
+
+        /// <summary>
+        /// Returns the most stable string representation.
+        /// </summary>
+        /// <returns>The stable representation string.</returns>
+        public string ToStableRepresentation()
+        {
+            if (this.Guid.HasValue)
+                return this.Guid.Value.ToString();
+
+            if (this.BuiltInParameter.HasValue)
+                return ((int)this.BuiltInParameter.Value).ToString();
+
+            if (!string.IsNullOrEmpty(this.Name))
+                return this.Name;
+
+            if (this.Id.HasValue)
+                return this.Id.Value.ToString();
+
+            return string.Empty;
+        }
+    }
+}

--- a/RevitExtensions/ParameterIdentifier.cs
+++ b/RevitExtensions/ParameterIdentifier.cs
@@ -12,24 +12,24 @@ namespace RevitExtensions
         /// <summary>
         /// Gets the built-in parameter value if the identifier represents one.
         /// </summary>
-        public BuiltInParameter? BuiltInParameter { get; private set; }
+        public BuiltInParameter? BuiltInParameter { get; internal set; }
 
         /// <summary>
         /// Gets the shared parameter guid if the identifier represents one.
         /// </summary>
-        public Guid? Guid { get; private set; }
+        public Guid? Guid { get; internal set; }
 
         /// <summary>
         /// Gets the parameter name if the identifier represents one.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; internal set; }
 
         /// <summary>
         /// Gets the element id value if the identifier represents one.
         /// </summary>
-        public long? Id { get; private set; }
+        public long? Id { get; internal set; }
 
-        private ParameterIdentifier() { }
+        public ParameterIdentifier() { }
 
         /// <summary>
         /// Parses a parameter identifier from a string.
@@ -67,56 +67,6 @@ namespace RevitExtensions
             return identifier;
         }
 
-        /// <summary>
-        /// Creates a <see cref="ParameterIdentifier"/> from a Revit <see cref="Parameter"/>.
-        /// </summary>
-        /// <param name="parameter">The parameter to convert.</param>
-        /// <returns>A new <see cref="ParameterIdentifier"/>.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
-        public static ParameterIdentifier FromParameter(Parameter parameter)
-        {
-            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
-
-            var identifier = new ParameterIdentifier();
-
-            var guid = TryGetGuid(parameter);
-            if (guid.HasValue)
-            {
-                identifier.Guid = guid.Value;
-                return identifier;
-            }
-
-            var bipProp = parameter.GetType().GetProperty("BuiltInParameter");
-            if (bipProp != null)
-            {
-                var bipValue = bipProp.GetValue(parameter);
-                if (bipValue is BuiltInParameter bip)
-                {
-                    identifier.BuiltInParameter = bip;
-                    return identifier;
-                }
-            }
-
-            if (parameter.Id != null)
-            {
-                var intValue = (int)parameter.Id.GetElementIdValue();
-                if (intValue < 0)
-                {
-                    identifier.BuiltInParameter = (BuiltInParameter)intValue;
-                    return identifier;
-                }
-
-                identifier.Id = parameter.Id.GetElementIdValue();
-            }
-
-            if (!string.IsNullOrEmpty(parameter.Definition?.Name))
-            {
-                identifier.Name = parameter.Definition.Name;
-                return identifier;
-            }
-
-            return identifier;
-        }
 
         /// <summary>
         /// Returns the most stable string representation.
@@ -139,25 +89,5 @@ namespace RevitExtensions
             return string.Empty;
         }
 
-        private static Guid? TryGetGuid(Parameter parameter)
-        {
-            var prop = parameter.GetType().GetProperty("GUID") ?? parameter.GetType().GetProperty("Guid");
-            if (prop == null) return null;
-            var value = prop.GetValue(parameter);
-            if (value == null) return null;
-            if (value is System.Guid g)
-            {
-                if (g == System.Guid.Empty) return null;
-                return g;
-            }
-            var type = value.GetType();
-            if (type.FullName == "System.Nullable`1[System.Guid]")
-            {
-                var ng = (System.Nullable<System.Guid>)value;
-                if (ng.HasValue && ng.Value != System.Guid.Empty) return ng.Value;
-                return null;
-            }
-            return null;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce `ParameterIdentifier` for parsing parameter keys
- add tests covering parsing and stable representation logic

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_6854785ac3d083269d2190e5bbe0e142