### PR TITLE
Handle bool and DateTime conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,3 +405,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 nupkgs/
+.nuke/

--- a/RevitApiStubs/RevitApiStubs.csproj
+++ b/RevitApiStubs/RevitApiStubs.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <ImplicitUsings>false</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project>

--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -11,10 +11,12 @@ namespace RevitExtensions.Tests
         public void GetParameter_NegativeInt_UsesBuiltInParameter()
         {
             var element = new Element(new ElementId(1));
-            var param = element.GetParameter("-5");
+            var expected = new Parameter((BuiltInParameter)(-5));
+            element.Parameters.Add(expected);
 
-            Assert.NotNull(param);
-            Assert.Equal((BuiltInParameter)(-5), param.BuiltInParameter);
+            var param = element.GetParameter(ParameterIdentifier.Parse("-5"));
+
+            Assert.Same(expected, param);
         }
 
         [Fact]
@@ -22,7 +24,7 @@ namespace RevitExtensions.Tests
         {
             var element = new Element(new ElementId(1));
             element.Parameters.Add(new Parameter(new ElementId(7)));
-            var param = element.GetParameter("7");
+            var param = element.GetParameter(ParameterIdentifier.Parse("7"));
 
             Assert.NotNull(param);
             Assert.Equal(7L, param.Id.GetElementIdValue());
@@ -33,7 +35,9 @@ namespace RevitExtensions.Tests
         {
             var element = new Element(new ElementId(1));
             var guid = Guid.NewGuid();
-            var param = element.GetParameter(guid.ToString());
+            var p = new Parameter(guid);
+            element.Parameters.Add(p);
+            var param = element.GetParameter(ParameterIdentifier.Parse(guid.ToString()));
 
             Assert.NotNull(param);
             Assert.Equal(guid, param.Guid);
@@ -43,10 +47,12 @@ namespace RevitExtensions.Tests
         public void GetParameter_Name_UsesLookup()
         {
             var element = new Element(new ElementId(1));
-            var param = element.GetParameter("Foo");
+            var expected = new Parameter("Foo");
+            element.Parameters.Add(expected);
 
-            Assert.NotNull(param);
-            Assert.Equal("Foo", param.Name);
+            var param = element.GetParameter(ParameterIdentifier.Parse("Foo"));
+
+            Assert.Same(expected, param);
         }
 
         [Fact]
@@ -59,11 +65,247 @@ namespace RevitExtensions.Tests
 
             var element = new Element(doc, new ElementId(2)) { TypeId = new ElementId(20) };
 
-            var param = element.GetParameter("9");
+            var param = element.GetParameter(ParameterIdentifier.Parse("9"));
 
             Assert.NotNull(param);
             Assert.Equal(9L, param.Id.GetElementIdValue());
             Assert.Same(type.Parameters[0], param);
+        }
+
+        [Fact]
+        public void LookupParameter_GuidNotFound_FallsBackToName()
+        {
+            var source = new Parameter(Guid.NewGuid()) { Definition = { Name = "Foo" } };
+            var identifier = source.ToIdentifier();
+
+            var element = new Element(new ElementId(3));
+            element.Parameters.Add(new Parameter("Foo"));
+
+            var param = element.LookupParameter(identifier);
+
+            Assert.NotNull(param);
+            Assert.Equal("Foo", param.Name);
+        }
+
+        [Fact]
+        public void GetParameter_GuidNotFound_ReturnsNull()
+        {
+            var source = new Parameter(Guid.NewGuid()) { Definition = { Name = "Foo" } };
+            var identifier = source.ToIdentifier();
+
+            var element = new Element(new ElementId(6));
+            element.Parameters.Add(new Parameter("Foo"));
+
+            var param = element.GetParameter(identifier);
+
+            Assert.Null(param);
+        }
+
+        [Fact]
+        public void LookupParameter_IdNotFound_FallsBackToName()
+        {
+            var source = new Parameter(new ElementId(8)) { Definition = { Name = "Bar" } };
+            var identifier = source.ToIdentifier();
+
+            var element = new Element(new ElementId(4));
+            element.Parameters.Add(new Parameter("Bar"));
+
+            var param = element.LookupParameter(identifier);
+
+            Assert.NotNull(param);
+            Assert.Equal("Bar", param.Name);
+        }
+
+        [Fact]
+        public void GetParameterValue_FromParameter_ReturnsStoredValue()
+        {
+            var parameter = new Parameter("A") { StorageType = StorageType.String };
+            parameter.Set("foo");
+
+            var value = parameter.GetParameterValue();
+
+            Assert.Equal("foo", value);
+        }
+
+        [Fact]
+        public void GetParameterValue_FromElementIdentifier_ReturnsStoredValue()
+        {
+            var element = new Element(new ElementId(1));
+            var parameter = new Parameter(new ElementId(5)) { StorageType = StorageType.Integer };
+            parameter.Set(42);
+            element.Parameters.Add(parameter);
+
+            var value = element.GetParameterValue(ParameterIdentifier.Parse("5"));
+
+            Assert.Equal(42, value);
+        }
+
+        [Fact]
+        public void GetParameterValue_Generic_ConvertsValue()
+        {
+            var parameter = new Parameter("B") { StorageType = StorageType.String };
+            parameter.Set("123");
+
+            var value = parameter.GetParameterValue<int>();
+
+            Assert.Equal(123, value);
+        }
+
+        [Fact]
+        public void Element_GetParameterValue_Generic_ConvertsValue()
+        {
+            var element = new Element(new ElementId(2));
+            var parameter = new Parameter(new ElementId(7)) { StorageType = StorageType.ElementId };
+            parameter.Set(new ElementId(7));
+            element.Parameters.Add(parameter);
+
+            var value = element.GetParameterValue<long>(ParameterIdentifier.Parse("7"));
+
+            Assert.Equal(7L, value);
+        }
+
+        [Fact]
+        public void SetParameterValue_SetsValue()
+        {
+            var parameter = new Parameter("A") { StorageType = StorageType.Double };
+
+            parameter.SetParameterValue(3.5);
+
+            Assert.Equal(3.5, parameter.AsDouble());
+        }
+
+        [Fact]
+        public void TrySetParameterValue_ReadOnly_ReturnsFalseWithReason()
+        {
+            var parameter = new Parameter("A") { StorageType = StorageType.String, IsReadOnly = true };
+
+            var result = parameter.TrySetParameterValue("bar", out var reason);
+
+            Assert.False(result);
+            Assert.Equal("Parameter is read-only.", reason);
+        }
+
+        [Fact]
+        public void SetParameterValue_ReadOnly_Throws()
+        {
+            var parameter = new Parameter("A") { StorageType = StorageType.String, IsReadOnly = true };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => parameter.SetParameterValue("bar"));
+            Assert.Equal("Parameter is read-only.", ex.Message);
+        }
+
+        [Fact]
+        public void Element_SetParameterValue_UpdatesParameter()
+        {
+            var element = new Element(new ElementId(1));
+            var parameter = new Parameter(new ElementId(10)) { StorageType = StorageType.Integer };
+            element.Parameters.Add(parameter);
+
+            element.SetParameterValue(ParameterIdentifier.Parse("10"), 5);
+
+            Assert.Equal(5, parameter.AsInteger());
+        }
+
+        [Fact]
+        public void Element_TrySetParameterValue_NotFound_ReturnsFalse()
+        {
+            var element = new Element(new ElementId(1));
+
+            var result = element.TrySetParameterValue(ParameterIdentifier.Parse("42"), 1, out var reason);
+
+            Assert.False(result);
+            Assert.Equal("Parameter not found.", reason);
+        }
+
+        [Fact]
+        public void Element_SetParameterValue_NotFound_Throws()
+        {
+            var element = new Element(new ElementId(1));
+
+            var ex = Assert.Throws<InvalidOperationException>(() => element.SetParameterValue(ParameterIdentifier.Parse("99"), 2));
+            Assert.Equal("Parameter not found.", ex.Message);
+        }
+
+        [Fact]
+        public void LookupParameterValue_NullValue_TriesNextParameter()
+        {
+            var source = new Parameter(new ElementId(11)) { Definition = { Name = "Baz" }, StorageType = StorageType.String };
+            // leave value null
+            var identifier = source.ToIdentifier();
+
+            var element = new Element(new ElementId(5));
+            element.Parameters.Add(source);
+            var second = new Parameter("Baz") { StorageType = StorageType.String };
+            second.Set("value");
+            element.Parameters.Add(second);
+
+            var value = element.LookupParameterValue(identifier);
+
+            Assert.Equal("value", value);
+        }
+
+        [Fact]
+        public void GetParameterValue_NullValue_ReturnsNull()
+        {
+            var source = new Parameter(new ElementId(12)) { Definition = { Name = "Qux" }, StorageType = StorageType.String };
+            var identifier = source.ToIdentifier();
+
+            var element = new Element(new ElementId(6));
+            element.Parameters.Add(source);
+            element.Parameters.Add(new Parameter("Qux") { StorageType = StorageType.String });
+
+            var value = element.GetParameterValue(identifier);
+
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void SetParameterValue_BoolToInteger_WritesZeroOrOne()
+        {
+            var parameter = new Parameter("B") { StorageType = StorageType.Integer };
+
+            parameter.SetParameterValue(true);
+
+            Assert.Equal(1, parameter.AsInteger());
+
+            parameter.SetParameterValue(false);
+
+            Assert.Equal(0, parameter.AsInteger());
+        }
+
+        [Fact]
+        public void GetParameterValue_BoolFromInteger_ParsesBool()
+        {
+            var parameter = new Parameter("C") { StorageType = StorageType.Integer };
+            parameter.Set(1);
+
+            var value = parameter.GetParameterValue<bool>();
+
+            Assert.True(value);
+        }
+
+        [Fact]
+        public void SetParameterValue_DateTimeToString_WritesIso()
+        {
+            var dt = new DateTime(2024, 6, 20, 12, 0, 0, DateTimeKind.Utc);
+            var parameter = new Parameter("D") { StorageType = StorageType.String };
+
+            parameter.SetParameterValue(dt);
+
+            Assert.Equal(dt.ToString("o"), parameter.AsString());
+        }
+
+        [Fact]
+        public void GetParameterValue_DateTimeFromInteger_ParsesUnixSeconds()
+        {
+            var dt = new DateTime(2024, 6, 20, 12, 0, 0, DateTimeKind.Utc);
+            var seconds = (int)new DateTimeOffset(dt).ToUnixTimeSeconds();
+            var parameter = new Parameter("E") { StorageType = StorageType.Integer };
+            parameter.Set(seconds);
+
+            var value = parameter.GetParameterValue<DateTime>();
+
+            Assert.Equal(dt, value);
         }
     }
 }

--- a/RevitExtensions.Tests/ParameterIdentifierTests.cs
+++ b/RevitExtensions.Tests/ParameterIdentifierTests.cs
@@ -1,0 +1,119 @@
+using System;
+using Autodesk.Revit.DB;
+using RevitExtensions;
+using Xunit;
+
+namespace RevitExtensions.Tests
+{
+    public class ParameterIdentifierTests
+    {
+        [Fact]
+        public void Parse_GuidString_SetsGuid()
+        {
+            var guid = Guid.NewGuid().ToString();
+
+            var id = ParameterIdentifier.Parse(guid);
+
+            Assert.Equal(Guid.Parse(guid), id.Guid);
+            Assert.Null(id.BuiltInParameter);
+            Assert.Null(id.Name);
+            Assert.Null(id.Id);
+            Assert.Equal(guid, id.ToStableRepresentation());
+        }
+
+        [Fact]
+        public void Parse_NegativeInt_SetsBuiltInParameter()
+        {
+            var id = ParameterIdentifier.Parse("-42");
+
+            Assert.Equal((BuiltInParameter)(-42), id.BuiltInParameter);
+            Assert.Null(id.Guid);
+            Assert.Null(id.Name);
+            Assert.Null(id.Id);
+            Assert.Equal("-42", id.ToStableRepresentation());
+        }
+
+        [Fact]
+        public void Parse_PositiveInt_SetsId()
+        {
+            var id = ParameterIdentifier.Parse("15");
+
+            Assert.Equal(15L, id.Id);
+            Assert.Null(id.Guid);
+            Assert.Null(id.BuiltInParameter);
+            Assert.Null(id.Name);
+            Assert.Equal("15", id.ToStableRepresentation());
+        }
+
+        [Fact]
+        public void Parse_Name_SetsName()
+        {
+            var id = ParameterIdentifier.Parse("Foo");
+
+            Assert.Equal("Foo", id.Name);
+            Assert.Null(id.Guid);
+            Assert.Null(id.BuiltInParameter);
+            Assert.Null(id.Id);
+            Assert.Equal("Foo", id.ToStableRepresentation());
+        }
+
+        [Fact]
+        public void ToIdentifier_Guid_ReturnsIdentifierWithGuid()
+        {
+            var guid = Guid.NewGuid();
+            var parameter = new Parameter(guid);
+
+            var id = parameter.ToIdentifier();
+
+            Assert.Equal(guid, id.Guid);
+            Assert.Equal(guid.ToString(), parameter.ToIdentifier().ToStableRepresentation());
+        }
+
+        [Fact]
+        public void ToIdentifier_BuiltInParameter_ReturnsIdentifier()
+        {
+            var parameter = new Parameter((BuiltInParameter)(-10));
+
+            var id = parameter.ToIdentifier();
+
+            Assert.Equal((BuiltInParameter)(-10), id.BuiltInParameter);
+            Assert.Equal(parameter.Definition.Name, id.Name);
+            Assert.Equal("-10", parameter.ToIdentifier().ToStableRepresentation());
+        }
+
+        [Fact]
+        public void ToIdentifier_Name_ReturnsIdentifier()
+        {
+            var parameter = new Parameter("Foo");
+
+            var id = parameter.ToIdentifier();
+
+            Assert.Equal("Foo", id.Name);
+            Assert.Equal("Foo", parameter.ToIdentifier().ToStableRepresentation());
+        }
+
+        [Fact]
+        public void ToIdentifier_Id_ReturnsIdentifier()
+        {
+            var parameter = new Parameter(new ElementId(5));
+
+            var id = parameter.ToIdentifier();
+
+            Assert.Equal(5L, id.Id);
+            Assert.Equal("5", parameter.ToIdentifier().ToStableRepresentation());
+        }
+
+        [Fact]
+        public void ToIdentifier_GuidWithName_IncludesName()
+        {
+            var guid = Guid.NewGuid();
+            var parameter = new Parameter(guid);
+            parameter.Definition.Name = "Foo";
+
+            var id = parameter.ToIdentifier();
+
+            Assert.Equal(guid, id.Guid);
+            Assert.Equal("Foo", id.Name);
+        }
+    }
+}

--- a/RevitExtensions/CustomConvert.cs
+++ b/RevitExtensions/CustomConvert.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Globalization;
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Provides helper conversions for parameter values.
+    /// </summary>
+    internal static class CustomConvert
+    {
+        public static object ChangeType(object value, Type targetType)
+        {
+            if (value == null) return null;
+            if (targetType.IsInstanceOfType(value)) return value;
+
+            if (targetType == typeof(bool) || targetType == typeof(bool?))
+                return ToBoolean(value);
+
+            if (targetType == typeof(DateTime) || targetType == typeof(DateTime?))
+                return ToDateTime(value);
+
+            return Convert.ChangeType(value, Nullable.GetUnderlyingType(targetType) ?? targetType);
+        }
+
+        public static bool ToBoolean(object value)
+        {
+            return value switch
+            {
+                bool b => b,
+                int i => i != 0,
+                long l => l != 0,
+                string s => bool.Parse(s),
+                _ => Convert.ToBoolean(value)
+            };
+        }
+
+        public static DateTime ToDateTime(object value)
+        {
+            return value switch
+            {
+                DateTime dt => dt,
+                int i => DateTimeOffset.FromUnixTimeSeconds(i).UtcDateTime,
+                long l => DateTimeOffset.FromUnixTimeSeconds(l).UtcDateTime,
+                double d => DateTime.FromOADate(d),
+                string s => DateTime.Parse(s, null, DateTimeStyles.RoundtripKind),
+                _ => (DateTime)Convert.ChangeType(value, typeof(DateTime))
+            };
+        }
+
+        public static bool TryToDouble(object value, out double result)
+        {
+            result = default;
+            switch (value)
+            {
+                case double d:
+                    result = d; return true;
+                case bool b:
+                    result = b ? 1 : 0; return true;
+                case DateTime dt:
+                    result = dt.ToOADate(); return true;
+                case string s:
+                    if (double.TryParse(s, out result)) return true;
+                    if (bool.TryParse(s, out var sb)) { result = sb ? 1 : 0; return true; }
+                    if (DateTime.TryParse(s, null, DateTimeStyles.RoundtripKind, out var sd)) { result = sd.ToOADate(); return true; }
+                    return false;
+                default:
+                    if (value is IConvertible conv)
+                    {
+                        try { result = Convert.ToDouble(conv); return true; }
+                        catch { }
+                    }
+                    return false;
+            }
+        }
+
+        public static bool TryToInt32(object value, out int result)
+        {
+            result = default;
+            switch (value)
+            {
+                case int i:
+                    result = i; return true;
+                case bool b:
+                    result = b ? 1 : 0; return true;
+                case DateTime dt:
+                    result = (int)new DateTimeOffset(dt).ToUnixTimeSeconds(); return true;
+                case string s:
+                    if (int.TryParse(s, out result)) return true;
+                    if (bool.TryParse(s, out var sb)) { result = sb ? 1 : 0; return true; }
+                    if (DateTime.TryParse(s, null, DateTimeStyles.RoundtripKind, out var sd)) { result = (int)new DateTimeOffset(sd).ToUnixTimeSeconds(); return true; }
+                    return false;
+                default:
+                    if (value is IConvertible conv)
+                    {
+                        try { result = Convert.ToInt32(conv); return true; }
+                        catch { }
+                    }
+                    return false;
+            }
+        }
+
+        public static bool TryToElementId(object value, out ElementId id)
+        {
+            id = null;
+            switch (value)
+            {
+                case ElementId e:
+                    id = e; return true;
+                case int i:
+                    id = new ElementId(i); return true;
+                case long l:
+                    id = new ElementId((int)l); return true;
+                case string s when int.TryParse(s, out var vi):
+                    id = new ElementId(vi); return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static string ToString(object value)
+        {
+            return value switch
+            {
+                DateTime dt => dt.ToString("o"),
+                ElementId eid => eid.GetElementIdValue().ToString(),
+                _ => value?.ToString()
+            };
+        }
+    }
+}

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Autodesk.Revit.DB;
+using System.Globalization;
 
 namespace RevitExtensions
 {
@@ -20,57 +21,532 @@ namespace RevitExtensions
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
 
-            Parameter parameter = null;
+            return element.GetParameter(ParameterIdentifier.Parse(identifier));
+        }
 
-            if (int.TryParse(identifier, out var intValue))
+        /// <summary>
+        /// Gets a parameter from the element or its type using a <see cref="ParameterIdentifier"/>.
+        /// </summary>
+        /// <param name="element">The element to search.</param>
+        /// <param name="identifier">The parameter identifier.</param>
+        /// <returns>The found parameter or null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static Parameter GetParameter(this Element element, ParameterIdentifier identifier)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            Parameter FindOn(Element source)
             {
+                Parameter p = null;
+                if (identifier.Guid.HasValue)
+                {
+                    p = source.get_Parameter(identifier.Guid.Value);
+                    if (p != null) return p;
+                }
+
+                if (identifier.BuiltInParameter.HasValue)
+                {
+                    p = source.get_Parameter(identifier.BuiltInParameter.Value);
+                    if (p != null) return p;
+                }
+
+                if (identifier.Id.HasValue)
+                {
+                    var target = identifier.Id.Value;
+                    foreach (Parameter ip in source.Parameters)
+                    {
+                        if (ip.Id != null && ip.Id.GetElementIdValue() == target)
+                            return ip;
+                    }
+                }
+
+                if (!identifier.Guid.HasValue &&
+                    !identifier.BuiltInParameter.HasValue &&
+                    !identifier.Id.HasValue &&
+                    !string.IsNullOrEmpty(identifier.Name))
+                {
+                    return source.LookupParameter(identifier.Name);
+                }
+
+                return null;
+            }
+
+            var parameter = FindOn(element);
+            if (parameter != null) return parameter;
+
+            using var typeElement = element.GetElementType();
+            if (typeElement != null)
+            {
+                parameter = FindOn(typeElement);
+            }
+
+            return parameter;
+        }
+
+        /// <summary>
+        /// Looks up a parameter from the element or its type using a <see cref="ParameterIdentifier"/>.
+        /// This method will fall back to the parameter name when the strict lookup fails.
+        /// </summary>
+        /// <param name="element">The element to search.</param>
+        /// <param name="identifier">The parameter identifier.</param>
+        /// <returns>The found parameter or null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static Parameter LookupParameter(this Element element, ParameterIdentifier identifier)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            var parameter = element.GetParameter(identifier);
+            if (parameter != null) return parameter;
+
+            if (!string.IsNullOrEmpty(identifier.Name))
+            {
+                parameter = element.LookupParameter(identifier.Name);
+                if (parameter != null) return parameter;
+
+                using var typeElement = element.GetElementType();
+                return typeElement?.LookupParameter(identifier.Name);
+            }
+
+            return null;
+        }
+
+        public static Parameter LookupParameter(this Element element, string identifier)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            return element.LookupParameter(ParameterIdentifier.Parse(identifier));
+        }
+
+        /// <summary>
+        /// Retrieves the value stored in the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <typeparam name="T">The desired return type.</typeparam>
+        /// <returns>The parameter value or null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        public static object GetParameterValue(this Parameter parameter)
+        {
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+
+            return parameter.StorageType switch
+            {
+                StorageType.Double => (object)parameter.AsDouble(),
+                StorageType.Integer => parameter.AsInteger(),
+                StorageType.String => parameter.AsString(),
+                StorageType.ElementId => parameter.AsElementId()?.GetElementIdValue(),
+                _ => null,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves the value stored in the parameter and converts it to the specified type.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <typeparam name="T">The desired return type.</typeparam>
+        /// <returns>The converted value or default if the parameter value is null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        public static T GetParameterValue<T>(this Parameter parameter)
+        {
+            var value = parameter.GetParameterValue();
+            if (value == null) return default;
+
+            if (value is T t) return t;
+
+            var target = typeof(T);
+
+            return (T)CustomConvert.ChangeType(value, target);
+        }
+
+        /// <summary>
+        /// Retrieves the value of the parameter identified on the element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier string.</param>
+        /// <returns>The parameter value or null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static object GetParameterValue(this Element element, string identifier)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            return element.GetParameterValue(ParameterIdentifier.Parse(identifier));
+        }
+
+        /// <summary>
+        /// Retrieves the value of the parameter identified on the element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier.</param>
+        /// <returns>The parameter value or null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static object GetParameterValue(this Element element, ParameterIdentifier identifier)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            using var parameter = element.GetParameter(identifier);
+            return parameter?.GetParameterValue();
+        }
+
+        /// <summary>
+        /// Retrieves the value of the parameter identified on the element and converts it to the specified type.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier string.</param>
+        /// <typeparam name="T">The desired return type.</typeparam>
+        /// <returns>The converted value or default if the parameter is not found or has a null value.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static T GetParameterValue<T>(this Element element, string identifier)
+        {
+            var value = element.GetParameterValue(identifier);
+            if (value == null) return default;
+
+            if (value is T t) return t;
+
+            var target = typeof(T);
+
+            return (T)CustomConvert.ChangeType(value, target);
+        }
+
+        /// <summary>
+        /// Retrieves the value of the parameter identified on the element and converts it to the specified type.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier.</param>
+        /// <typeparam name="T">The desired return type.</typeparam>
+        /// <returns>The converted value or default if the parameter is not found or has a null value.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static T GetParameterValue<T>(this Element element, ParameterIdentifier identifier)
+        {
+            var value = element.GetParameterValue(identifier);
+            if (value == null) return default;
+
+            if (value is T t) return t;
+
+            var target = typeof(T);
+
+            return (T)CustomConvert.ChangeType(value, target);
+        }
+
+        /// <summary>
+        /// Looks up the value of the parameter identified on the element.
+        /// If the retrieved parameter has a null value, additional parameters with the same name are searched.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier string.</param>
+        /// <returns>The parameter value or null.</returns>
+        public static object LookupParameterValue(this Element element, string identifier)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            return element.LookupParameterValue(ParameterIdentifier.Parse(identifier));
+        }
+
+        /// <summary>
+        /// Looks up the value of the parameter identified on the element.
+        /// If the retrieved parameter has a null value, additional parameters with the same name are searched.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier.</param>
+        /// <returns>The parameter value or null.</returns>
+        public static object LookupParameterValue(this Element element, ParameterIdentifier identifier)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            using var parameter = element.LookupParameter(identifier);
+            var value = parameter?.GetParameterValue();
+
+            if (value == null && parameter != null)
+            {
+                var name = identifier.Name ?? parameter.Definition?.Name;
+                if (!string.IsNullOrEmpty(name))
+                {
+                    foreach (Parameter p in element.Parameters)
+                    {
+                        if (p == parameter) continue;
+                        if (p.Definition?.Name == name)
+                        {
+                            var next = p.GetParameterValue();
+                            if (next != null) return next;
+                        }
+                    }
+
+                    using var typeElement = element.GetElementType();
+                    if (typeElement != null)
+                    {
+                        foreach (Parameter p in typeElement.Parameters)
+                        {
+                            if (p.Definition?.Name == name)
+                            {
+                                var next = p.GetParameterValue();
+                                if (next != null) return next;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        public static T LookupParameterValue<T>(this Element element, string identifier)
+        {
+            var value = element.LookupParameterValue(identifier);
+            if (value == null) return default;
+
+            if (value is T t) return t;
+
+            var target = typeof(T);
+
+            return (T)CustomConvert.ChangeType(value, target);
+        }
+
+        public static T LookupParameterValue<T>(this Element element, ParameterIdentifier identifier)
+        {
+            var value = element.LookupParameterValue(identifier);
+            if (value == null) return default;
+
+            if (value is T t) return t;
+
+            var target = typeof(T);
+
+            return (T)CustomConvert.ChangeType(value, target);
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <param name="value">The value to set.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when setting the value fails.</exception>
+        public static void SetParameterValue(this Parameter parameter, object value)
+        {
+            if (!parameter.TrySetParameterValue(value, out var reason))
+                throw new InvalidOperationException(reason);
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <param name="value">The value to set.</param>
+        /// <param name="reason">Outputs the failure reason.</param>
+        /// <returns>True if successful.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        public static bool TrySetParameterValue(this Parameter parameter, object value, out string reason)
+        {
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+
+            reason = null;
+
+            if (parameter.IsReadOnly)
+            {
+                reason = "Parameter is read-only.";
+                return false;
+            }
+
+            bool result;
+            switch (parameter.StorageType)
+            {
+                case StorageType.Double:
+                    double d;
+                    if (!CustomConvert.TryToDouble(value, out d))
+                    {
+                        reason = "Value must be a number.";
+                        return false;
+                    }
+
+                    if (parameter.AsDouble() == d) return true;
+                    result = parameter.Set(d);
+                    break;
+                case StorageType.Integer:
+                    int i;
+                    if (!CustomConvert.TryToInt32(value, out i))
+                    {
+                        reason = "Value must be an integer.";
+                        return false;
+                    }
+
+                    if (parameter.AsInteger() == i) return true;
+                    result = parameter.Set(i);
+                    break;
+                case StorageType.String:
+                    string str = CustomConvert.ToString(value);
+
+                    if (string.Equals(parameter.AsString(), str)) return true;
+                    result = parameter.Set(str);
+                    break;
+                case StorageType.ElementId:
+                    ElementId id;
+                    if (!CustomConvert.TryToElementId(value, out id))
+                    {
+                        reason = "Value must be an ElementId.";
+                        return false;
+                    }
+
+                    var current = parameter.AsElementId();
+                    if ((current == null && id == null) ||
+                        (current != null && current.GetElementIdValue() == id.GetElementIdValue()))
+                        return true;
+                    result = parameter.Set(id);
+                    break;
+                default:
+                    reason = "Unsupported storage type.";
+                    return false;
+            }
+
+            if (!result)
+            {
+                reason = "Parameter set failed.";
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter identified on the element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier string.</param>
+        /// <param name="value">The value to set.</param>
+        /// <returns>True if successful.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static void SetParameterValue(this Element element, string identifier, object value)
+        {
+            if (!element.TrySetParameterValue(identifier, value, out var reason))
+                throw new InvalidOperationException(reason);
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter identified on the element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier.</param>
+        /// <param name="value">The value to set.</param>
+        /// <returns>True if successful.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static void SetParameterValue(this Element element, ParameterIdentifier identifier, object value)
+        {
+            if (!element.TrySetParameterValue(identifier, value, out var reason))
+                throw new InvalidOperationException(reason);
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter identified on the element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier string.</param>
+        /// <param name="value">The value to set.</param>
+        /// <param name="reason">Outputs the failure reason.</param>
+        /// <returns>True if successful.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static bool TrySetParameterValue(this Element element, string identifier, object value, out string reason)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            return element.TrySetParameterValue(ParameterIdentifier.Parse(identifier), value, out reason);
+        }
+
+        /// <summary>
+        /// Sets the value of the parameter identified on the element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="identifier">The parameter identifier.</param>
+        /// <param name="value">The value to set.</param>
+        /// <param name="reason">Outputs the failure reason.</param>
+        /// <returns>True if successful.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
+        public static bool TrySetParameterValue(this Element element, ParameterIdentifier identifier, object value, out string reason)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (identifier == null) throw new ArgumentNullException(nameof(identifier));
+
+            using var parameter = element.GetParameter(identifier);
+            if (parameter == null)
+            {
+                reason = "Parameter not found.";
+                return false;
+            }
+
+            return parameter.TrySetParameterValue(value, out reason);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ParameterIdentifier"/> for the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>A <see cref="ParameterIdentifier"/> identifying the parameter.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
+        public static ParameterIdentifier ToIdentifier(this Parameter parameter)
+        {
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+
+            var identifier = new ParameterIdentifier();
+
+            var guid = TryGetGuid(parameter);
+            if (guid.HasValue)
+            {
+                identifier.Guid = guid.Value;
+            }
+
+            var bipProp = parameter.GetType().GetProperty("BuiltInParameter");
+            if (bipProp != null)
+            {
+                var bipValue = bipProp.GetValue(parameter);
+                if (bipValue is BuiltInParameter bip)
+                {
+                    identifier.BuiltInParameter = bip;
+                }
+            }
+
+            if (parameter.Id != null)
+            {
+                var intValue = (int)parameter.Id.GetElementIdValue();
                 if (intValue < 0)
                 {
-                    var bip = (BuiltInParameter)intValue;
-                    parameter = element.get_Parameter(bip);
-                    if (parameter == null)
-                    {
-                        using var type = element.GetElementType();
-                        parameter = type?.get_Parameter(bip);
-                    }
-                    return parameter;
+                    if (!identifier.BuiltInParameter.HasValue)
+                        identifier.BuiltInParameter = (BuiltInParameter)intValue;
                 }
                 else
                 {
-                    long idValue = intValue;
-                    foreach (Parameter p in element.Parameters)
-                    {
-                        if (p.Id != null && p.Id.GetElementIdValue() == idValue)
-                            return p;
-                    }
-                    using var typeElem = element.GetElementType();
-                    if (typeElem != null)
-                    {
-                        foreach (Parameter p in typeElem.Parameters)
-                        {
-                            if (p.Id != null && p.Id.GetElementIdValue() == idValue)
-                                return p;
-                        }
-                    }
-                    return null;
+                    identifier.Id = parameter.Id.GetElementIdValue();
                 }
             }
 
-            if (Guid.TryParse(identifier, out var guid))
+            if (!string.IsNullOrEmpty(parameter.Definition?.Name))
             {
-                parameter = element.get_Parameter(guid);
-                if (parameter == null)
-                {
-                    using var type = element.GetElementType();
-                    parameter = type?.get_Parameter(guid);
-                }
-                return parameter;
+                identifier.Name = parameter.Definition.Name;
             }
 
-            parameter = element.LookupParameter(identifier);
-            if (parameter != null) return parameter;
-            using var typeElement = element.GetElementType();
-            return typeElement?.LookupParameter(identifier);
+            return identifier;
+        }
+
+        private static Guid? TryGetGuid(Parameter parameter)
+        {
+            var prop = parameter.GetType().GetProperty("GUID") ?? parameter.GetType().GetProperty("Guid");
+            if (prop == null) return null;
+            var value = prop.GetValue(parameter);
+            if (value == null) return null;
+            if (value is Guid g)
+            {
+                if (g == Guid.Empty) return null;
+                return g;
+            }
+            var type = value.GetType();
+            if (type.FullName == "System.Nullable`1[System.Guid]")
+            {
+                var ng = (Guid?)value;
+                if (ng.HasValue && ng.Value != Guid.Empty) return ng.Value;
+                return null;
+            }
+            return null;
         }
     }
 }

--- a/RevitExtensions/ParameterIdentifier.cs
+++ b/RevitExtensions/ParameterIdentifier.cs
@@ -1,0 +1,93 @@
+using System;
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Represents a parameter identifier that can be expressed as a built-in parameter,
+    /// a shared parameter guid, a name, or an element id.
+    /// </summary>
+    public class ParameterIdentifier
+    {
+        /// <summary>
+        /// Gets the built-in parameter value if the identifier represents one.
+        /// </summary>
+        public BuiltInParameter? BuiltInParameter { get; internal set; }
+
+        /// <summary>
+        /// Gets the shared parameter guid if the identifier represents one.
+        /// </summary>
+        public Guid? Guid { get; internal set; }
+
+        /// <summary>
+        /// Gets the parameter name if the identifier represents one.
+        /// </summary>
+        public string Name { get; internal set; }
+
+        /// <summary>
+        /// Gets the element id value if the identifier represents one.
+        /// </summary>
+        public long? Id { get; internal set; }
+
+        public ParameterIdentifier() { }
+
+        /// <summary>
+        /// Parses a parameter identifier from a string.
+        /// </summary>
+        /// <param name="value">The identifier string.</param>
+        /// <returns>A <see cref="ParameterIdentifier"/> instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/> is null.</exception>
+        public static ParameterIdentifier Parse(string value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+
+            var identifier = new ParameterIdentifier();
+
+            if (System.Guid.TryParse(value, out var guid))
+            {
+                identifier.Guid = guid;
+                return identifier;
+            }
+
+            if (int.TryParse(value, out var intValue))
+            {
+                if (intValue < 0)
+                {
+                    identifier.BuiltInParameter = (BuiltInParameter)intValue;
+                }
+                else
+                {
+                    identifier.Id = intValue;
+                }
+
+                return identifier;
+            }
+
+            identifier.Name = value;
+            return identifier;
+        }
+
+
+        /// <summary>
+        /// Returns the most stable string representation.
+        /// </summary>
+        /// <returns>The stable representation string.</returns>
+        public string ToStableRepresentation()
+        {
+            if (this.Guid.HasValue)
+                return this.Guid.Value.ToString();
+
+            if (this.BuiltInParameter.HasValue)
+                return ((int)this.BuiltInParameter.Value).ToString();
+
+            if (!string.IsNullOrEmpty(this.Name))
+                return this.Name;
+
+            if (this.Id.HasValue)
+                return this.Id.Value.ToString();
+
+            return string.Empty;
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary
- convert bool and DateTime values when getting/setting parameters
- updated `ParameterExtensions` to support conversions across storage types
- added unit tests for bool and DateTime scenarios
- extract custom conversions into new `CustomConvert` class
- introduce `LookupParameter`/`LookupParameterValue` for fallback searching

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`
- `./build.sh --target BuildAll`


------
https://chatgpt.com/codex/tasks/task_e_6854785ac3d083269d2190e5bbe0e142