### PR TITLE
Add transaction helpers

### DIFF
--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -400,4 +400,51 @@ namespace Autodesk.Revit.DB
     {
     }
 
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.Transaction.
+    /// </summary>
+    public class Transaction : IDisposable
+    {
+        public Document Document { get; }
+        public string Name { get; }
+
+        public bool IsDisposed { get; private set; }
+        public bool IsStarted { get; private set; }
+
+        public Transaction(Document document, string name)
+        {
+            Document = document;
+            Name = name;
+        }
+
+        public TransactionStatus Start()
+        {
+            IsStarted = true;
+            return TransactionStatus.Started;
+        }
+
+        public TransactionStatus Commit()
+        {
+            if (!IsStarted)
+                return TransactionStatus.Error;
+
+            IsStarted = false;
+            return TransactionStatus.Committed;
+        }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.TransactionStatus.
+    /// </summary>
+    public enum TransactionStatus
+    {
+        Uninitialized,
+        Started,
+        Committed,
+        RolledBack,
+        Error
+    }
+
 }

--- a/RevitExtensions.Tests/DocumentExtensionsTests.cs
+++ b/RevitExtensions.Tests/DocumentExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Autodesk.Revit.DB;
 using RevitExtensions;
 using Xunit;
@@ -72,6 +73,39 @@ namespace RevitExtensions.Tests
             Assert.Same(doc, collector.Document);
             Assert.Equal(cats, collector.Categories);
             Assert.True(collector.OnlyElementTypes);
+        }
+
+        [Fact]
+        public void StartTransaction_StartsAndReturnsTransaction()
+        {
+            var doc = new Document();
+
+            using var t = doc.StartTransaction("Foo");
+
+            Assert.Same(doc, t.Document);
+            Assert.Equal("Foo", t.Name);
+            Assert.True(t.IsStarted);
+        }
+
+        [Fact]
+        public void CommitAndEnsure_Committed_DoesNotThrow()
+        {
+            var doc = new Document();
+            using var t = doc.StartTransaction("Foo");
+
+            t.CommitAndEnsure();
+
+            Assert.False(t.IsStarted);
+        }
+
+        [Fact]
+        public void CommitAndEnsure_Failed_Throws()
+        {
+            var doc = new Document();
+            using var t = new Transaction(doc, "Foo");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => t.CommitAndEnsure());
+            Assert.Equal("Failed to commit transaction.", ex.Message);
         }
     }
 }

--- a/RevitExtensions/DocumentExtensions.cs
+++ b/RevitExtensions/DocumentExtensions.cs
@@ -99,6 +99,32 @@ namespace RevitExtensions
             return new FilteredElementCollector(document)
                 .TypesOf(categories);
         }
+
+        /// <summary>
+        /// Creates and starts a transaction.
+        /// </summary>
+        /// <param name="document">The owning document.</param>
+        /// <param name="name">The transaction name.</param>
+        /// <returns>The started transaction.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="document"/> or <paramref name="name"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the transaction fails to start.</exception>
+        public static Transaction StartTransaction(this Document document, string name)
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (name == null) throw new ArgumentNullException(nameof(name));
+
+            var transaction = new Transaction(document, name);
+            var status = transaction.Start();
+            if (status != TransactionStatus.Started)
+            {
+                transaction.Dispose();
+                throw new InvalidOperationException("Failed to start transaction.");
+            }
+
+            return transaction;
+        }
     }
 }
 

--- a/RevitExtensions/TransactionExtensions.cs
+++ b/RevitExtensions/TransactionExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="Transaction"/>.
+    /// </summary>
+    public static class TransactionExtensions
+    {
+        /// <summary>
+        /// Commits the transaction and ensures it succeeded.
+        /// </summary>
+        /// <param name="transaction">The transaction to commit.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="transaction"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the transaction fails to commit.</exception>
+        public static void CommitAndEnsure(this Transaction transaction)
+        {
+            if (transaction == null) throw new ArgumentNullException(nameof(transaction));
+
+            var status = transaction.Commit();
+            if (status != TransactionStatus.Committed)
+            {
+                throw new InvalidOperationException("Failed to commit transaction.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend Document with `StartTransaction`
- add `CommitAndEnsure` extension for Transaction
- create Transaction and TransactionStatus stubs
- test new transaction helpers

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_68566653879c8326a7dfc9f2468f7f48