### PR TITLE
Enable nullable reference types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,5 @@ The stubs only support the surface area covered by the tests and should not be u
 Use `using var` with elements, parameters, and any other `IDisposable` objects when they are only used temporarily and not returned from the method.
 
 To account for API differences across Revit versions, conditional compilation symbols may be used. Symbols follow the pattern `REVIT20xx`, `REVIT20xx_OR_ABOVE`, and `REVIT20xx_OR_LESS` and can be combined to include or exclude code for specific main releases.
+
+All projects should enable C# nullable reference types by setting `<Nullable>enable</Nullable>` in the project file. Methods, properties and fields must be annotated with `?` when they can contain `null`.

--- a/RevitApiStubs/RevitApiStubs.csproj
+++ b/RevitApiStubs/RevitApiStubs.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <ImplicitUsings>false</ImplicitUsings>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/RevitExtensions.Tests/RevitExtensions.Tests.csproj
+++ b/RevitExtensions.Tests/RevitExtensions.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\RevitExtensions\RevitExtensions.csproj" />

--- a/RevitExtensions/CustomConvert.cs
+++ b/RevitExtensions/CustomConvert.cs
@@ -100,7 +100,7 @@ namespace RevitExtensions
             }
         }
 
-        public static bool TryToElementId(object value, out ElementId id)
+        public static bool TryToElementId(object value, out ElementId? id)
         {
             id = null;
             switch (value)
@@ -118,7 +118,7 @@ namespace RevitExtensions
             }
         }
 
-        public static string ToString(object value)
+        public static string? ToString(object value)
         {
             return value switch
             {

--- a/RevitExtensions/ElementExtensions.cs
+++ b/RevitExtensions/ElementExtensions.cs
@@ -85,7 +85,7 @@ namespace RevitExtensions
         /// </summary>
         /// <param name="element">The element.</param>
         /// <returns>The element type or null if unavailable.</returns>
-        public static Element GetElementType(this Element element)
+        public static Element? GetElementType(this Element element)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
 

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -16,7 +16,7 @@ namespace RevitExtensions
         /// <param name="identifier">The parameter identifier string.</param>
         /// <returns>The found parameter or null.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
-        public static Parameter GetParameter(this Element element, string identifier)
+        public static Parameter? GetParameter(this Element element, string identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -31,7 +31,7 @@ namespace RevitExtensions
         /// <param name="identifier">The parameter identifier.</param>
         /// <returns>The found parameter or null.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
-        public static Parameter GetParameter(this Element element, ParameterIdentifier identifier)
+        public static Parameter? GetParameter(this Element element, ParameterIdentifier identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -92,7 +92,7 @@ namespace RevitExtensions
         /// <param name="identifier">The parameter identifier.</param>
         /// <returns>The found parameter or null.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
-        public static Parameter LookupParameter(this Element element, ParameterIdentifier identifier)
+        public static Parameter? LookupParameter(this Element element, ParameterIdentifier identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -112,7 +112,7 @@ namespace RevitExtensions
             return null;
         }
 
-        public static Parameter LookupParameter(this Element element, string identifier)
+        public static Parameter? LookupParameter(this Element element, string identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -127,7 +127,7 @@ namespace RevitExtensions
         /// <typeparam name="T">The desired return type.</typeparam>
         /// <returns>The parameter value or null.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
-        public static object GetParameterValue(this Parameter parameter)
+        public static object? GetParameterValue(this Parameter parameter)
         {
             if (parameter == null) throw new ArgumentNullException(nameof(parameter));
 
@@ -167,7 +167,7 @@ namespace RevitExtensions
         /// <param name="identifier">The parameter identifier string.</param>
         /// <returns>The parameter value or null.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
-        public static object GetParameterValue(this Element element, string identifier)
+        public static object? GetParameterValue(this Element element, string identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -182,7 +182,7 @@ namespace RevitExtensions
         /// <param name="identifier">The parameter identifier.</param>
         /// <returns>The parameter value or null.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
-        public static object GetParameterValue(this Element element, ParameterIdentifier identifier)
+        public static object? GetParameterValue(this Element element, ParameterIdentifier identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -238,7 +238,7 @@ namespace RevitExtensions
         /// <param name="element">The element.</param>
         /// <param name="identifier">The parameter identifier string.</param>
         /// <returns>The parameter value or null.</returns>
-        public static object LookupParameterValue(this Element element, string identifier)
+        public static object? LookupParameterValue(this Element element, string identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -253,7 +253,7 @@ namespace RevitExtensions
         /// <param name="element">The element.</param>
         /// <param name="identifier">The parameter identifier.</param>
         /// <returns>The parameter value or null.</returns>
-        public static object LookupParameterValue(this Element element, ParameterIdentifier identifier)
+        public static object? LookupParameterValue(this Element element, ParameterIdentifier identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -339,7 +339,7 @@ namespace RevitExtensions
         /// <param name="reason">Outputs the failure reason.</param>
         /// <returns>True if successful.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
-        public static bool TrySetParameterValue(this Parameter parameter, object value, out string reason)
+        public static bool TrySetParameterValue(this Parameter parameter, object value, out string? reason)
         {
             if (parameter == null) throw new ArgumentNullException(nameof(parameter));
 
@@ -446,7 +446,7 @@ namespace RevitExtensions
         /// <param name="reason">Outputs the failure reason.</param>
         /// <returns>True if successful.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
-        public static bool TrySetParameterValue(this Element element, string identifier, object value, out string reason)
+        public static bool TrySetParameterValue(this Element element, string identifier, object value, out string? reason)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -463,7 +463,7 @@ namespace RevitExtensions
         /// <param name="reason">Outputs the failure reason.</param>
         /// <returns>True if successful.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
-        public static bool TrySetParameterValue(this Element element, ParameterIdentifier identifier, object value, out string reason)
+        public static bool TrySetParameterValue(this Element element, ParameterIdentifier identifier, object value, out string? reason)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));

--- a/RevitExtensions/ParameterIdentifier.cs
+++ b/RevitExtensions/ParameterIdentifier.cs
@@ -22,7 +22,7 @@ namespace RevitExtensions
         /// <summary>
         /// Gets the parameter name if the identifier represents one.
         /// </summary>
-        public string Name { get; internal set; }
+        public string? Name { get; internal set; }
 
         /// <summary>
         /// Gets the element id value if the identifier represents one.

--- a/RevitExtensions/RevitExtensions.csproj
+++ b/RevitExtensions/RevitExtensions.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Helper extensions for Autodesk Revit API.</Description>
     <PackageId>RevitExtensions</PackageId>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>


### PR DESCRIPTION
## Summary
- document nullable reference types usage
- annotate APIs with nullable reference types

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_685683d6adc48326b08684b41455f719