### PR TITLE
Improve README placement and NuGet docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 This repository contains helper extensions for the Autodesk Revit API. The goal is to make it easier to use APIs across Revit versions. One important helper is retrieving an element id as a `long` value regardless of the Revit release. The library depends on the `Revit_All_Main_Versions_API_x64` NuGet package and builds against either .NET Framework 4.8 or .NET 8 depending on the Revit version. A tiny `RevitApiStubs` project is included for unit tests so they can run without Autodesk binaries.
 
+## Usage examples
+
+```csharp
+using Autodesk.Revit.DB;
+using RevitExtensions;
+
+// start a transaction and update a parameter
+using var tx = document.StartTransaction("Set parameter");
+element.SetParameterValue("Comments", "Hello");
+tx.CommitAndEnsure();
+
+// get all wall instances in the document
+var walls = document.InstancesOf<Wall>().ToElements();
+
+// retrieve an element id as a long
+long id = element.GetElementIdValue();
+```
+
+
 ## Building packages
 
 Use [NUKE](https://nuke.build) to build and package the project. Compile all
@@ -77,20 +96,3 @@ The library exposes helpers for common Revit API patterns.
 Represents a parameter by name, GUID, built‑in parameter or element id. It can
 be parsed from a string and provides a stable representation.
 
-### Usage examples
-
-```csharp
-using Autodesk.Revit.DB;
-using RevitExtensions;
-
-// start a transaction and update a parameter
-using var tx = document.StartTransaction("Set parameter");
-element.SetParameterValue("Comments", "Hello");
-tx.CommitAndEnsure();
-
-// get all wall instances in the document
-var walls = document.InstancesOf<Wall>().ToElements();
-
-// retrieve an element id as a long
-long id = element.GetElementIdValue();
-```

--- a/RevitExtensions/PackageReadme.md
+++ b/RevitExtensions/PackageReadme.md
@@ -1,0 +1,56 @@
+# RevitExtensions
+
+Helper extensions for the Autodesk Revit API. The library smooths over differences between Revit versions so code can use a consistent set of helpers.
+
+## Available extensions
+
+All extension methods live in the `RevitExtensions` namespace. The library exposes helpers for common Revit API patterns.
+
+### DocumentExtensions
+
+- `InstancesOf<T>()` / `TypesOf<T>()` – create a `FilteredElementCollector` for element instances or types.
+- Overloads allow filtering by a `BuiltInCategory` or multiple categories.
+- `StartTransaction`, `StartTransactionGroup` and `StartSubTransaction` start the respective transaction object and ensure it began successfully.
+
+### FilteredElementCollectorExtensions
+
+- `InstancesOf<T>()` / `TypesOf<T>()` – filter an existing collector by type.
+- Overloads filter by a category or multiple categories.
+- `ForEach(Action<Element>)` – enumerates the collector and disposes each element after the action executes.
+
+### ElementExtensions
+
+- `GetElementIdValue()` – returns the element id as a `long` regardless of Revit version.
+- `CanEdit(out EditStatus)` – determines if the element can be edited in the current workshared document.
+- `GetElementType()` – retrieves the element's type element.
+
+### ParameterExtensions
+
+- `GetParameter` and `LookupParameter` – search for a parameter on an element or its type using a flexible `ParameterIdentifier` or name.
+- `GetParameterValue` and `SetParameterValue` – read and write parameter values with automatic type conversion.
+
+### TransactionExtensions
+
+- `CommitAndEnsure`, `AssimilateAndEnsure` – commit or assimilate a transaction (or group) and throw if the operation fails.
+
+### ParameterIdentifier
+
+Represents a parameter by name, GUID, built‑in parameter or element id. It can be parsed from a string and provides a stable representation.
+
+## Usage examples
+
+```csharp
+using Autodesk.Revit.DB;
+using RevitExtensions;
+
+// start a transaction and update a parameter
+using var tx = document.StartTransaction("Set parameter");
+element.SetParameterValue("Comments", "Hello");
+tx.CommitAndEnsure();
+
+// get all wall instances in the document
+var walls = document.InstancesOf<Wall>().ToElements();
+
+// retrieve an element id as a long
+long id = element.GetElementIdValue();
+```

--- a/RevitExtensions/RevitExtensions.csproj
+++ b/RevitExtensions/RevitExtensions.csproj
@@ -9,7 +9,7 @@
     <PackageId>RevitExtensions</PackageId>
     <Authors>RevitExtensions</Authors>
     <PackageTags>Revit;API;Extensions</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>PackageReadme.md</PackageReadmeFile>
     <!-- Default Revit API package versions; overridden when packaging -->
     <RevitApiPackageVersion>2026.0.0</RevitApiPackageVersion>
     <RevitApiPackageVersion Condition="'$(TargetFramework)' == 'net48'">2024.2.0</RevitApiPackageVersion>
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="PackageReadme.md" Pack="true" PackagePath="" />
     <None Include="../README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- move usage examples near the top of the main README
- create a package-specific README focused on how to use the library
- reference the new package readme from the project file

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_685694c313448326bdaf1483ed6d43b0