### PR TITLE
Add Document.GetElement overloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,4 @@ Use `using var` with elements, parameters, and any other `IDisposable` objects w
 To account for API differences across Revit versions, conditional compilation symbols may be used. Symbols follow the pattern `REVIT20xx`, `REVIT20xx_OR_ABOVE`, and `REVIT20xx_OR_LESS` and can be combined to include or exclude code for specific main releases.
 
 All projects should enable C# nullable reference types by setting `<Nullable>enable</Nullable>` in the project file. Methods, properties and fields must be annotated with `?` when they can contain `null`.
+Extension methods that wrap Revit API calls should reflect the API's nullability. If `Document.GetElement` might return `null`, your wrapper should return `Element?`.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ The library exposes helpers for common Revit API patterns.
 
 - `GetElementIdValue()` – returns the element id as a `long` regardless of
   Revit version.
+- `ToElement()` – retrieve an element from a document by id. Generic overload
+  casts the result to the specified element type.
 - `CanEdit(out EditStatus)` – determines if the element can be edited in the
   current workshared document.
 - `GetElementType()` – retrieves the element's type element.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ The library exposes helpers for common Revit API patterns.
 - `InstancesOf<T>()` / `TypesOf<T>()` – create a `FilteredElementCollector` for
   element instances or types.
 - Overloads allow filtering by a `BuiltInCategory` or multiple categories.
+- `GetElement()` overloads retrieve an element by id (`ElementId`, `int` or `long`).
+  Generic versions cast the result to the specified element type and may return
+  `null` when the id does not exist.
 - `StartTransaction`, `StartTransactionGroup` and `StartSubTransaction` start
   the respective transaction object and ensure it began successfully.
 
@@ -159,6 +162,7 @@ The library exposes helpers for common Revit API patterns.
 ### BuiltInParameterExtensions
 
 - `ToElementId()` – convert a built-in parameter enum value to its corresponding `ElementId`.
+- `int` and `long` also provide `ToElementId()` helpers.
 
 ### TransactionExtensions
 

--- a/RevitExtensions.Tests/DocumentExtensionsTests.cs
+++ b/RevitExtensions.Tests/DocumentExtensionsTests.cs
@@ -76,6 +76,71 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
+        public void GetElement_ElementId_ReturnsElement()
+        {
+            var doc = new Document();
+            var id = new ElementId(1);
+            var element = new Element(doc, id);
+            doc.AddElement(element);
+
+            var result = doc.GetElement(id);
+
+            Assert.Same(element, result);
+        }
+
+        [Fact]
+        public void GetElement_Int_ReturnsElement()
+        {
+            var doc = new Document();
+            var id = new ElementId(2);
+            var element = new Element(doc, id);
+            doc.AddElement(element);
+
+            var result = doc.GetElement(2);
+
+            Assert.Same(element, result);
+        }
+
+        [Fact]
+        public void GetElement_Long_ReturnsElement()
+        {
+            var doc = new Document();
+            var id = new ElementId(3);
+            var element = new Element(doc, id);
+            doc.AddElement(element);
+
+            var result = doc.GetElement(3L);
+
+            Assert.Same(element, result);
+        }
+
+        [Fact]
+        public void GetElement_Generic_ReturnsElementOfType()
+        {
+            var doc = new Document();
+            var id = new ElementId(4);
+            var wall = new Wall(id);
+            doc.AddElement(wall);
+
+            var result = doc.GetElement<Wall>(4);
+
+            Assert.Same(wall, result);
+        }
+
+        [Fact]
+        public void GetElement_Generic_WrongType_ReturnsNull()
+        {
+            var doc = new Document();
+            var id = new ElementId(5);
+            var element = new Element(doc, id);
+            doc.AddElement(element);
+
+            var result = doc.GetElement<Wall>(5);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
         public void StartTransaction_StartsAndReturnsTransaction()
         {
             var doc = new Document();

--- a/RevitExtensions.Tests/ElementExtensionsTests.cs
+++ b/RevitExtensions.Tests/ElementExtensionsTests.cs
@@ -93,5 +93,44 @@ namespace RevitExtensions.Tests
             using var type = element.GetElementType();
             Assert.Null(type);
         }
+
+        [Fact]
+        public void ToElement_ReturnsElementFromDocument()
+        {
+            var doc = new Document();
+            var id = new ElementId(11);
+            var element = new Element(doc, id);
+            doc.AddElement(element);
+
+            var result = id.ToElement(doc);
+
+            Assert.Same(element, result);
+        }
+
+        [Fact]
+        public void ToElement_Generic_ReturnsTypedElement()
+        {
+            var doc = new Document();
+            var id = new ElementId(12);
+            var wall = new Wall(id);
+            doc.AddElement(wall);
+
+            var result = id.ToElement<Wall>(doc);
+
+            Assert.Same(wall, result);
+        }
+
+        [Fact]
+        public void ToElement_Generic_WrongType_ReturnsNull()
+        {
+            var doc = new Document();
+            var id = new ElementId(13);
+            var element = new Element(doc, id);
+            doc.AddElement(element);
+
+            var result = id.ToElement<Wall>(doc);
+
+            Assert.Null(result);
+        }
     }
 }

--- a/RevitExtensions.Tests/NumericExtensionsTests.cs
+++ b/RevitExtensions.Tests/NumericExtensionsTests.cs
@@ -1,0 +1,27 @@
+using Autodesk.Revit.DB;
+using RevitExtensions;
+using Xunit;
+
+namespace RevitExtensions.Tests
+{
+    public class NumericExtensionsTests
+    {
+        [Fact]
+        public void ToElementId_Int_ReturnsElementId()
+        {
+            int value = 5;
+            var id = value.ToElementId();
+
+            Assert.Equal(5L, id.GetElementIdValue());
+        }
+
+        [Fact]
+        public void ToElementId_Long_ReturnsElementId()
+        {
+            long value = 7;
+            var id = value.ToElementId();
+
+            Assert.Equal(7L, id.GetElementIdValue());
+        }
+    }
+}

--- a/RevitExtensions/DocumentExtensions.cs
+++ b/RevitExtensions/DocumentExtensions.cs
@@ -101,6 +101,95 @@ namespace RevitExtensions
         }
 
         /// <summary>
+        /// Gets an element by id.
+        /// </summary>
+        /// <param name="document">The document to search.</param>
+        /// <param name="id">The element id.</param>
+        /// <returns>The element with the given id, or <c>null</c> if none exists.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> or <paramref name="id"/> is null.</exception>
+        public static Element? GetElement(this Document document, ElementId id)
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (id == null) throw new ArgumentNullException(nameof(id));
+
+            return document.GetElement(id);
+        }
+
+        /// <summary>
+        /// Gets an element by integer id.
+        /// </summary>
+        /// <param name="document">The document to search.</param>
+        /// <param name="id">The element id.</param>
+        /// <returns>The element with the given id, or <c>null</c> if none exists.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> is null.</exception>
+        public static Element? GetElement(this Document document, int id)
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return document.GetElement(id.ToElementId());
+        }
+
+        /// <summary>
+        /// Gets an element by long id.
+        /// </summary>
+        /// <param name="document">The document to search.</param>
+        /// <param name="id">The element id.</param>
+        /// <returns>The element with the given id, or <c>null</c> if none exists.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> is null.</exception>
+        public static Element? GetElement(this Document document, long id)
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return document.GetElement(id.ToElementId());
+        }
+
+        /// <summary>
+        /// Gets an element of the specified type by id.
+        /// </summary>
+        /// <typeparam name="T">The expected element type.</typeparam>
+        /// <param name="document">The document to search.</param>
+        /// <param name="id">The element id.</param>
+        /// <returns>The element cast to <typeparamref name="T"/> if found; otherwise null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> or <paramref name="id"/> is null.</exception>
+        public static T? GetElement<T>(this Document document, ElementId id) where T : Element
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (id == null) throw new ArgumentNullException(nameof(id));
+
+            return document.GetElement(id) as T;
+        }
+
+        /// <summary>
+        /// Gets an element of the specified type by integer id.
+        /// </summary>
+        /// <typeparam name="T">The expected element type.</typeparam>
+        /// <param name="document">The document to search.</param>
+        /// <param name="id">The element id.</param>
+        /// <returns>The element cast to <typeparamref name="T"/> if found; otherwise null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> is null.</exception>
+        public static T? GetElement<T>(this Document document, int id) where T : Element
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return document.GetElement(id.ToElementId()) as T;
+        }
+
+        /// <summary>
+        /// Gets an element of the specified type by long id.
+        /// </summary>
+        /// <typeparam name="T">The expected element type.</typeparam>
+        /// <param name="document">The document to search.</param>
+        /// <param name="id">The element id.</param>
+        /// <returns>The element cast to <typeparamref name="T"/> if found; otherwise null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="document"/> is null.</exception>
+        public static T? GetElement<T>(this Document document, long id) where T : Element
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return document.GetElement(id.ToElementId()) as T;
+        }
+
+        /// <summary>
         /// Creates and starts a transaction.
         /// </summary>
         /// <param name="document">The owning document.</param>

--- a/RevitExtensions/DocumentExtensions.cs
+++ b/RevitExtensions/DocumentExtensions.cs
@@ -112,7 +112,7 @@ namespace RevitExtensions
             if (document == null) throw new ArgumentNullException(nameof(document));
             if (id == null) throw new ArgumentNullException(nameof(id));
 
-            return document.GetElement(id);
+            return id.ToElement(document);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace RevitExtensions
         {
             if (document == null) throw new ArgumentNullException(nameof(document));
 
-            return document.GetElement(id.ToElementId());
+            return id.ToElementId().ToElement(document);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace RevitExtensions
         {
             if (document == null) throw new ArgumentNullException(nameof(document));
 
-            return document.GetElement(id.ToElementId());
+            return id.ToElementId().ToElement(document);
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace RevitExtensions
             if (document == null) throw new ArgumentNullException(nameof(document));
             if (id == null) throw new ArgumentNullException(nameof(id));
 
-            return document.GetElement(id) as T;
+            return id.ToElement<T>(document);
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace RevitExtensions
         {
             if (document == null) throw new ArgumentNullException(nameof(document));
 
-            return document.GetElement(id.ToElementId()) as T;
+            return id.ToElementId().ToElement<T>(document);
         }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace RevitExtensions
         {
             if (document == null) throw new ArgumentNullException(nameof(document));
 
-            return document.GetElement(id.ToElementId()) as T;
+            return id.ToElementId().ToElement<T>(document);
         }
 
         /// <summary>

--- a/RevitExtensions/ElementExtensions.cs
+++ b/RevitExtensions/ElementExtensions.cs
@@ -36,6 +36,41 @@ namespace RevitExtensions
         }
 
         /// <summary>
+        /// Gets the element with this id from the given document.
+        /// </summary>
+        /// <param name="id">The element id.</param>
+        /// <param name="document">The owning document.</param>
+        /// <returns>The element or <c>null</c> if not found.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="id"/> or <paramref name="document"/> is null.
+        /// </exception>
+        public static Element? ToElement(this ElementId id, Document document)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return document.GetElement(id);
+        }
+
+        /// <summary>
+        /// Gets the element with this id from the given document and casts it to the specified type.
+        /// </summary>
+        /// <typeparam name="T">The expected element type.</typeparam>
+        /// <param name="id">The element id.</param>
+        /// <param name="document">The owning document.</param>
+        /// <returns>The element cast to <typeparamref name="T"/> if found; otherwise <c>null</c>.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="id"/> or <paramref name="document"/> is null.
+        /// </exception>
+        public static T? ToElement<T>(this ElementId id, Document document) where T : Element
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            return document.GetElement(id) as T;
+        }
+
+        /// <summary>
         /// Determines if the element can be edited.
         /// </summary>
         /// <param name="element">The element to check.</param>

--- a/RevitExtensions/NumericExtensions.cs
+++ b/RevitExtensions/NumericExtensions.cs
@@ -1,0 +1,34 @@
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Extension methods for numeric values.
+    /// </summary>
+    public static class NumericExtensions
+    {
+        /// <summary>
+        /// Converts an <see cref="int"/> value to an <see cref="ElementId"/>.
+        /// </summary>
+        /// <param name="value">The id value.</param>
+        /// <returns>An <see cref="ElementId"/> created from the value.</returns>
+        public static ElementId ToElementId(this int value)
+        {
+            return new ElementId(value);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="long"/> value to an <see cref="ElementId"/>.
+        /// </summary>
+        /// <param name="value">The id value.</param>
+        /// <returns>An <see cref="ElementId"/> created from the value.</returns>
+        public static ElementId ToElementId(this long value)
+        {
+#if REVIT2024_OR_ABOVE
+            return new ElementId(value);
+#else
+            return new ElementId((int)value);
+#endif
+        }
+    }
+}

--- a/RevitExtensions/PackageReadme.md
+++ b/RevitExtensions/PackageReadme.md
@@ -10,6 +10,9 @@ All extension methods live in the `RevitExtensions` namespace. The library expos
 
 - `InstancesOf<T>()` / `TypesOf<T>()` – create a `FilteredElementCollector` for element instances or types.
 - Overloads allow filtering by a `BuiltInCategory` or multiple categories.
+- `GetElement()` overloads retrieve an element by id (`ElementId`, `int` or `long`).
+  Generic versions cast the result to the specified element type and may return
+  `null` if the id does not exist.
 - `StartTransaction`, `StartTransactionGroup` and `StartSubTransaction` start the respective transaction object and ensure it began successfully.
 
 ### FilteredElementCollectorExtensions
@@ -48,6 +51,7 @@ All extension methods live in the `RevitExtensions` namespace. The library expos
 ### BuiltInParameterExtensions
 
 - `ToElementId()` – convert a built-in parameter enum value to its corresponding `ElementId`.
+- `int` and `long` also provide `ToElementId()` helpers.
 
 ### TransactionExtensions
 

--- a/RevitExtensions/PackageReadme.md
+++ b/RevitExtensions/PackageReadme.md
@@ -40,6 +40,8 @@ All extension methods live in the `RevitExtensions` namespace. The library expos
 ### ElementExtensions
 
 - `GetElementIdValue()` – returns the element id as a `long` regardless of Revit version.
+- `ToElement()` – retrieve an element from a document by id. Generic overload
+  casts the result to the specified element type.
 - `CanEdit(out EditStatus)` – determines if the element can be edited in the current workshared document.
 - `GetElementType()` – retrieves the element's type element.
 


### PR DESCRIPTION
## Summary
- add nullability instructions to AGENTS file
- return `Element?` from all `GetElement` overloads
- document that `GetElement` may return null
- add `ToElementId()` helpers for `int` and `long`
- use new helpers in `GetElement` methods

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_6859a0d99a74832698b51f1e46aee4af