### PR TITLE
Add generic ForEach overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The library exposes helpers for common Revit API patterns.
 - Overloads filter by a category or multiple categories.
 - `ForEach(Action<Element>)` – enumerates the collector and disposes each
   element after the action executes.
+- `ForEach<T>(Action<T>)` – enumerates the collector and invokes the action
+  for elements of type `T`, disposing non-matching elements.
 - `Where(ElementId, StringComparison, string)` – filter by a string parameter value.
 - `Where(BuiltInParameter, StringComparison, string)` – filter by a string parameter using a built-in id.
 - `Where(ElementId, Comparison, int)` – filter by an integer parameter value.

--- a/RevitExtensions.Tests/FilteredElementCollectorExtensionsTests.cs
+++ b/RevitExtensions.Tests/FilteredElementCollectorExtensionsTests.cs
@@ -28,6 +28,25 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
+        public void ForEach_Generic_SkipsNonMatchingElements()
+        {
+            var doc = new Document();
+            var collector = new FilteredElementCollector(doc);
+
+            var wall = new Wall(new ElementId(1));
+            var other = new Element(new ElementId(2));
+            collector.AddElement(wall);
+            collector.AddElement(other);
+
+            var results = new List<Wall>();
+            collector.ForEach<Wall>(results.Add);
+
+            Assert.Equal(new[] { wall }, results);
+            Assert.True(wall.IsDisposed);
+            Assert.True(other.IsDisposed);
+        }
+
+        [Fact]
         public void InstancesOf_MultiCategories_FiltersCollector()
         {
             var doc = new Document();

--- a/RevitExtensions/FilteredElementCollectorExtensions.cs
+++ b/RevitExtensions/FilteredElementCollectorExtensions.cs
@@ -177,6 +177,53 @@ namespace RevitExtensions
         }
 
         /// <summary>
+        /// Invokes an action for each element of type <typeparamref name="T"/> in the collector.
+        /// Elements not assignable to <typeparamref name="T"/> are disposed and skipped.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="collector">The collector to enumerate.</param>
+        /// <param name="action">The action to invoke for each element.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="collector"/> or <paramref name="action"/> is null.
+        /// </exception>
+        public static void ForEach<T>(this FilteredElementCollector collector, Action<T> action) where T : Element
+        {
+            if (collector == null) throw new ArgumentNullException(nameof(collector));
+            if (action == null) throw new ArgumentNullException(nameof(action));
+
+            var enumerator = collector.GetEnumerator();
+            try
+            {
+                while (enumerator.MoveNext())
+                {
+                    var element = enumerator.Current;
+                    if (element is T typed)
+                    {
+                        try
+                        {
+                            action(typed);
+                        }
+                        finally
+                        {
+                            typed.Dispose();
+                        }
+                    }
+                    else
+                    {
+                        if (element is IDisposable disposable)
+                        {
+                            disposable.Dispose();
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                (enumerator as IDisposable)?.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Filters the collector by comparing a parameter value.
         /// </summary>
         /// <param name="collector">The collector to filter.</param>

--- a/RevitExtensions/PackageReadme.md
+++ b/RevitExtensions/PackageReadme.md
@@ -22,6 +22,8 @@ All extension methods live in the `RevitExtensions` namespace. The library expos
 - `Instances()` / `Types()` – limit an existing collector to element instances or types.
 - Overloads filter by a category or multiple categories.
 - `ForEach(Action<Element>)` – enumerates the collector and disposes each element after the action executes.
+- `ForEach<T>(Action<T>)` – enumerates the collector and invokes the action for
+  elements of type `T`, disposing non-matching elements.
  - `Where(ElementId, StringComparison, string)` – filter by a string parameter value.
  - `Where(BuiltInParameter, StringComparison, string)` – filter by a string parameter using a built-in id.
  - `Where(ElementId, Comparison, int)` – filter by an integer parameter value.


### PR DESCRIPTION
## Summary
- add generic `ForEach<T>` overload to `FilteredElementCollectorExtensions`
- document new method in README and package readme
- test generic overload behavior

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_685dccc194948326b326f9a3a4d3b151