### PR TITLE
Add docs for spatial element helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,8 @@ To account for API differences across Revit versions, conditional compilation sy
 
 All projects should enable C# nullable reference types by setting `<Nullable>enable</Nullable>` in the project file. Methods, properties and fields must be annotated with `?` when they can contain `null`.
 Extension methods that wrap Revit API calls should reflect the API's nullability. If `Document.GetElement` might return `null`, your wrapper should return `Element?`.
+
+## Documentation
+All public methods must include XML summary comments describing what the method
+does and detailing its parameters. Keep these comments short and informative so
+they remain easy to read.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ The library exposes helpers for common Revit API patterns.
 Represents a parameter by name, GUID, built‑in parameter or element id. It can
 be parsed from a string and provides a stable representation.
 
+### SpatialElementExtensions
+
+- `SetRoom(Room, Phase?)` – store a reference to a room for the element.
+- `SetRoom(XYZ, Phase?)` – store a point used to resolve the room at runtime.
+- `SetSpace(Space, Phase?)` – store a reference to a space for the element.
+- `SetSpace(XYZ, Phase?)` – store a point used to resolve the space.
+- `GetRoom(Phase?)` – retrieve the associated room if available.
+- `GetSpace(Phase?)` – retrieve the associated space if available.
+- `GetRoomOrSpace(Phase?)` – return either the room or space.
+- `GetStoredRoomIds()` – dictionary of phase to stored room id.
+- `GetStoredSpaceIds()` – dictionary of phase to stored space id.
+- `GetStoredRoomPoints()` – dictionary of phase to stored room point.
+- `GetStoredSpacePoints()` – dictionary of phase to stored space point.
+- `HasStoredRoomOrSpace()` – returns true if any association exists.
+
 ### ParameterFilterSetBuilder and ParameterFilterSet
 
 Compose complex `ElementFilter` instances using nested AND/OR parameter rules.

--- a/RevitExtensions.Tests/SpatialElementExtensionsTests.cs
+++ b/RevitExtensions.Tests/SpatialElementExtensionsTests.cs
@@ -1,0 +1,85 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.DB.Mechanical;
+using RevitExtensions;
+using Xunit;
+
+namespace RevitExtensions.Tests
+{
+    public class SpatialElementExtensionsTests
+    {
+        [Fact]
+        public void SetRoom_WithRoom_ReturnsSameRoom()
+        {
+            var doc = new Document();
+            var room = new Room(new ElementId(1));
+            doc.AddElement(room);
+
+            var element = new Element(doc, new ElementId(2));
+            element.SetRoom(room);
+
+            using var result = element.GetRoom();
+            Assert.Same(room, result);
+        }
+
+        [Fact]
+        public void SetRoom_Point_UsesDocumentLookup()
+        {
+            var doc = new Document();
+            var room = new Room(new ElementId(3));
+            var point = new XYZ(1, 2, 3);
+            doc.AddElement(room);
+            doc.AddRoom(room, point);
+
+            var element = new Element(doc, new ElementId(4));
+            element.SetRoom(point);
+
+            using var result = element.GetRoom();
+            Assert.Same(room, result);
+        }
+
+        [Fact]
+        public void SetSpace_WithSpace_ReturnsSameSpace()
+        {
+            var doc = new Document();
+            var space = new Space(new ElementId(5));
+            doc.AddElement(space);
+
+            var element = new Element(doc, new ElementId(6));
+            element.SetSpace(space);
+
+            using var result = element.GetSpace();
+            Assert.Same(space, result);
+        }
+
+        [Fact]
+        public void StoredMappings_ReturnExpectedDictionaries()
+        {
+            var doc = new Document();
+            var phase = new Phase(new ElementId(10));
+            doc.AddElement(phase);
+
+            var room = new Room(new ElementId(20));
+            var space = new Space(new ElementId(30));
+            doc.AddElement(room);
+            doc.AddElement(space);
+
+            var spacePoint = new XYZ(2, 2, 2);
+
+            var element = new Element(doc, new ElementId(40));
+            element.SetRoom(room, phase);
+            element.SetSpace(spacePoint, phase);
+
+            var roomIds = element.GetStoredRoomIds();
+            var spacePoints = element.GetStoredSpacePoints();
+
+            Assert.Single(roomIds);
+            Assert.Equal(room.Id, roomIds[phase]);
+
+            Assert.Single(spacePoints);
+            Assert.Equal(spacePoint, spacePoints[phase]);
+
+            Assert.True(element.HasStoredRoomOrSpace());
+        }
+    }
+}

--- a/RevitExtensions/PackageReadme.md
+++ b/RevitExtensions/PackageReadme.md
@@ -74,6 +74,21 @@ All extension methods live in the `RevitExtensions` namespace. The library expos
 
 Represents a parameter by name, GUID, built‑in parameter or element id. It can be parsed from a string and provides a stable representation.
 
+### SpatialElementExtensions
+
+- `SetRoom(Room, Phase?)` – store a reference to a room for the element.
+- `SetRoom(XYZ, Phase?)` – store a point used to resolve the room at runtime.
+- `SetSpace(Space, Phase?)` – store a reference to a space for the element.
+- `SetSpace(XYZ, Phase?)` – store a point used to resolve the space.
+- `GetRoom(Phase?)` – retrieve the associated room if available.
+- `GetSpace(Phase?)` – retrieve the associated space if available.
+- `GetRoomOrSpace(Phase?)` – return either the room or space.
+- `GetStoredRoomIds()` – dictionary of phase to stored room id.
+- `GetStoredSpaceIds()` – dictionary of phase to stored space id.
+- `GetStoredRoomPoints()` – dictionary of phase to stored room point.
+- `GetStoredSpacePoints()` – dictionary of phase to stored space point.
+- `HasStoredRoomOrSpace()` – returns true if any association exists.
+
 ### ParameterFilterSetBuilder and ParameterFilterSet
 
 Compose complex `ElementFilter` instances using nested AND/OR parameter rules. The builder API mirrors the collector extension methods.

--- a/RevitExtensions/SpatialElementExtensions.cs
+++ b/RevitExtensions/SpatialElementExtensions.cs
@@ -1,0 +1,296 @@
+using System;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.DB.Mechanical;
+using System.Collections.Generic;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Extension methods for associating elements with rooms and spaces.
+    /// </summary>
+    public static class SpatialElementExtensions
+    {
+        private class StoredData
+        {
+            public ElementId? Id { get; set; }
+            public XYZ? Point { get; set; }
+            public ElementId? PhaseId { get; set; }
+            public bool IsRoom { get; set; }
+        }
+
+        private static readonly Dictionary<Element, List<StoredData>> _storage = new Dictionary<Element, List<StoredData>>();
+
+        private static StoredData? Find(Element element, bool isRoom, Phase? phase)
+        {
+            if (_storage.TryGetValue(element, out var list))
+            {
+                var phaseId = phase?.Id;
+                foreach (var d in list)
+                {
+                    if (d.IsRoom == isRoom &&
+                        ((phaseId == null && d.PhaseId == null) ||
+                         (phaseId != null && phaseId.Equals(d.PhaseId))))
+                        return d;
+                }
+            }
+            return null;
+        }
+
+        private static IEnumerable<StoredData> FindAll(Element element, bool isRoom)
+        {
+            if (_storage.TryGetValue(element, out var list))
+            {
+                foreach (var d in list)
+                {
+                    if (d.IsRoom == isRoom)
+                        yield return d;
+                }
+            }
+        }
+
+        private static void Set(Element element, bool isRoom, Phase? phase, ElementId? id, XYZ? point)
+        {
+            if (!_storage.TryGetValue(element, out var list))
+            {
+                list = new List<StoredData>();
+                _storage[element] = list;
+            }
+
+            var data = Find(element, isRoom, phase);
+            if (data != null)
+            {
+                data.Id = id;
+                data.Point = point;
+                data.PhaseId = phase?.Id;
+            }
+            else
+            {
+                list.Add(new StoredData { Id = id, Point = point, PhaseId = phase?.Id, IsRoom = isRoom });
+            }
+        }
+
+        /// <summary>
+        /// Associates the element with the given room in the specified phase.
+        /// </summary>
+        /// <param name="element">The element to tag.</param>
+        /// <param name="room">The room to store.</param>
+        /// <param name="phase">Optional phase the room belongs to.</param>
+        public static void SetRoom(this Element element, Room room, Phase? phase = null)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (room == null) throw new ArgumentNullException(nameof(room));
+
+            Set(element, true, phase, room.Id, null);
+        }
+
+        /// <summary>
+        /// Stores a point used to locate the room for the element.
+        /// </summary>
+        /// <param name="element">The element to tag.</param>
+        /// <param name="point">Point used to resolve the room.</param>
+        /// <param name="phase">Optional phase to use for room lookup.</param>
+        public static void SetRoom(this Element element, XYZ point, Phase? phase = null)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (point == null) throw new ArgumentNullException(nameof(point));
+
+            Set(element, true, phase, null, point);
+        }
+
+        /// <summary>
+        /// Associates the element with the given space in the specified phase.
+        /// </summary>
+        /// <param name="element">The element to tag.</param>
+        /// <param name="space">The space to store.</param>
+        /// <param name="phase">Optional phase the space belongs to.</param>
+        public static void SetSpace(this Element element, Space space, Phase? phase = null)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (space == null) throw new ArgumentNullException(nameof(space));
+
+            Set(element, false, phase, space.Id, null);
+        }
+
+        /// <summary>
+        /// Stores a point used to locate the space for the element.
+        /// </summary>
+        /// <param name="element">The element to tag.</param>
+        /// <param name="point">Point used to resolve the space.</param>
+        /// <param name="phase">Optional phase to use for space lookup.</param>
+        public static void SetSpace(this Element element, XYZ point, Phase? phase = null)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (point == null) throw new ArgumentNullException(nameof(point));
+
+            Set(element, false, phase, null, point);
+        }
+
+        /// <summary>
+        /// Retrieves the room associated with the element for the given phase.
+        /// </summary>
+        /// <param name="element">The element to inspect.</param>
+        /// <param name="phase">Optional phase for which to get the room.</param>
+        /// <returns>The resolved room or <c>null</c> if none is found.</returns>
+        public static Room? GetRoom(this Element element, Phase? phase = null)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            var data = Find(element, true, phase);
+            var doc = element.Document;
+            if (data != null && doc != null)
+            {
+                if (data.Id != null)
+                    return doc.GetElement(data.Id) as Room;
+                if (data.Point != null)
+                    return doc.GetRoomAtPoint(data.Point);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves the space associated with the element for the given phase.
+        /// </summary>
+        /// <param name="element">The element to inspect.</param>
+        /// <param name="phase">Optional phase for which to get the space.</param>
+        /// <returns>The resolved space or <c>null</c> if none is found.</returns>
+        public static Space? GetSpace(this Element element, Phase? phase = null)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            var data = Find(element, false, phase);
+            var doc = element.Document;
+            if (data != null && doc != null)
+            {
+                if (data.Id != null)
+                    return doc.GetElement(data.Id) as Space;
+                if (data.Point != null)
+                    return doc.GetSpaceAtPoint(data.Point);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves the room or space associated with the element for the given phase.
+        /// </summary>
+        /// <param name="element">The element to inspect.</param>
+        /// <param name="phase">Optional phase used for lookup.</param>
+        /// <returns>The room or space if available, otherwise <c>null</c>.</returns>
+        public static SpatialElement? GetRoomOrSpace(this Element element, Phase? phase = null)
+        {
+            return element.GetRoom(phase) ?? (SpatialElement?)element.GetSpace(phase);
+        }
+
+        /// <summary>
+        /// Retrieves all stored room ids for the element keyed by phase.
+        /// </summary>
+        /// <param name="element">Element to inspect.</param>
+        /// <returns>Mapping of phase to room id.</returns>
+        public static IReadOnlyDictionary<Phase, ElementId> GetStoredRoomIds(this Element element)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            var result = new Dictionary<Phase, ElementId>();
+            var doc = element.Document;
+
+            foreach (var d in FindAll(element, true))
+            {
+                if (d.Id != null)
+                {
+                    Phase? phase = d.PhaseId != null && doc != null ? doc.GetElement(d.PhaseId) as Phase : null;
+                    if (phase != null)
+                        result[phase] = d.Id;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Retrieves all stored space ids for the element keyed by phase.
+        /// </summary>
+        /// <param name="element">Element to inspect.</param>
+        /// <returns>Mapping of phase to space id.</returns>
+        public static IReadOnlyDictionary<Phase, ElementId> GetStoredSpaceIds(this Element element)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            var result = new Dictionary<Phase, ElementId>();
+            var doc = element.Document;
+
+            foreach (var d in FindAll(element, false))
+            {
+                if (d.Id != null)
+                {
+                    Phase? phase = d.PhaseId != null && doc != null ? doc.GetElement(d.PhaseId) as Phase : null;
+                    if (phase != null)
+                        result[phase] = d.Id;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Retrieves all stored room points for the element keyed by phase.
+        /// </summary>
+        /// <param name="element">Element to inspect.</param>
+        /// <returns>Mapping of phase to point.</returns>
+        public static IReadOnlyDictionary<Phase, XYZ> GetStoredRoomPoints(this Element element)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            var result = new Dictionary<Phase, XYZ>();
+            var doc = element.Document;
+
+            foreach (var d in FindAll(element, true))
+            {
+                if (d.Point != null)
+                {
+                    Phase? phase = d.PhaseId != null && doc != null ? doc.GetElement(d.PhaseId) as Phase : null;
+                    if (phase != null)
+                        result[phase] = d.Point;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Retrieves all stored space points for the element keyed by phase.
+        /// </summary>
+        /// <param name="element">Element to inspect.</param>
+        /// <returns>Mapping of phase to point.</returns>
+        public static IReadOnlyDictionary<Phase, XYZ> GetStoredSpacePoints(this Element element)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            var result = new Dictionary<Phase, XYZ>();
+            var doc = element.Document;
+
+            foreach (var d in FindAll(element, false))
+            {
+                if (d.Point != null)
+                {
+                    Phase? phase = d.PhaseId != null && doc != null ? doc.GetElement(d.PhaseId) as Phase : null;
+                    if (phase != null)
+                        result[phase] = d.Point;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Determines whether any room or space data is stored on the element.
+        /// </summary>
+        /// <param name="element">Element to inspect.</param>
+        /// <returns><c>true</c> if any room or space reference or point is stored; otherwise <c>false</c>.</returns>
+        public static bool HasStoredRoomOrSpace(this Element element)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            return _storage.TryGetValue(element, out var list) && list.Count > 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- mention documentation requirement in `AGENTS.md`
- document spatial element helper methods
- describe the new helpers in both readme files
- add retrieval helpers for stored room/space data
- expose method to check if an element has stored spatial data

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`


------
https://chatgpt.com/codex/tasks/task_e_686058b0269083268b89ed1cfe74890e