### PR TITLE
Improve unit expression parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ The library exposes helpers for common Revit API patterns.
 - `GetParameter` and `LookupParameter` – search for a parameter on an element or
   its type using a flexible `ParameterIdentifier` or name.
 - `GetParameterValue` and `SetParameterValue` – read and write parameter values
-  with automatic type conversion.
+  with automatic type conversion. When setting numeric parameters a string
+  starting with `=` is evaluated as an arithmetic expression that may include
+  length units like `m` or `cm`.
 - Generic overloads of `GetParameterValue` and `LookupParameterValue` return the
   requested type directly.
 - `TrySetParameterValue` methods expose failure reasons without throwing

--- a/RevitApiStubs/ForgeTypeId.cs
+++ b/RevitApiStubs/ForgeTypeId.cs
@@ -1,0 +1,110 @@
+using System;
+
+namespace Autodesk.Revit.DB
+{
+    /// <summary>
+    /// Backport of the ForgeTypeId class for Revit 2021 and earlier.
+    /// </summary>
+    public class ForgeTypeId : IEquatable<ForgeTypeId>
+    {
+        private string _typeId;
+
+        public ForgeTypeId()
+        {
+            _typeId = string.Empty;
+        }
+
+        public ForgeTypeId(string typeId)
+        {
+            _typeId = typeId ?? string.Empty;
+        }
+
+        public void Clear()
+        {
+            _typeId = string.Empty;
+        }
+
+        public bool Empty()
+        {
+            return string.IsNullOrEmpty(_typeId);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ForgeTypeId other && NameEquals(other);
+        }
+
+        public bool Equals(ForgeTypeId? other)
+        {
+            return other != null && NameEquals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return _typeId?.ToLowerInvariant().GetHashCode() ?? 0;
+        }
+
+        public override string ToString()
+        {
+            return _typeId;
+        }
+
+        public bool NameEquals(ForgeTypeId other)
+        {
+            if (other == null)
+                return false;
+
+            string thisBase = GetBaseTypeId(_typeId);
+            string otherBase = GetBaseTypeId(other._typeId);
+
+            return string.Equals(thisBase, otherBase, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public bool StrictlyEquals(ForgeTypeId other)
+        {
+            return other != null &&
+                   string.Equals(_typeId, other._typeId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetBaseTypeId(string typeId)
+        {
+            if (string.IsNullOrEmpty(typeId))
+                return string.Empty;
+
+            int dashIndex = typeId.IndexOf('-');
+            return dashIndex > 0 ? typeId.Substring(0, dashIndex) : typeId;
+        }
+
+        public static bool operator ==(ForgeTypeId? a, ForgeTypeId? b)
+        {
+            if (ReferenceEquals(a, b))
+                return true;
+            if (a is null || b is null)
+                return false;
+            return a.NameEquals(b);
+        }
+
+        public static bool operator !=(ForgeTypeId? a, ForgeTypeId? b)
+        {
+            return !(a == b);
+        }
+
+        public static bool operator <(ForgeTypeId? a, ForgeTypeId? b)
+        {
+            if (a is null || b is null)
+                return false;
+            return string.Compare(a._typeId, b._typeId, StringComparison.OrdinalIgnoreCase) < 0;
+        }
+
+        public static bool operator >(ForgeTypeId? a, ForgeTypeId? b)
+        {
+            if (a is null || b is null)
+                return false;
+            return string.Compare(a._typeId, b._typeId, StringComparison.OrdinalIgnoreCase) > 0;
+        }
+
+        public bool IsValidObject => !string.IsNullOrEmpty(_typeId);
+
+        public string TypeId => _typeId;
+    }
+}

--- a/RevitApiStubs/SpecTypeId.cs
+++ b/RevitApiStubs/SpecTypeId.cs
@@ -1,0 +1,49 @@
+#if REVIT2022_OR_LESS
+namespace Autodesk.Revit.DB
+{
+    /// <summary>
+    /// Minimal stand-in for the SpecTypeId class used to identify parameter data types.
+    /// Only the properties required by tests are included.
+    /// </summary>
+    public static class SpecTypeId
+    {
+        public static class String
+        {
+            public static ForgeTypeId Text { get; } = new ForgeTypeId("spec:string:text");
+            public static ForgeTypeId Multiline { get; } = new ForgeTypeId("spec:string:multiline");
+            public static ForgeTypeId Url { get; } = new ForgeTypeId("spec:string:url");
+            public static ForgeTypeId Custom { get; } = new ForgeTypeId("spec:string:custom");
+        }
+
+        public static class Int
+        {
+            public static ForgeTypeId Integer { get; } = new ForgeTypeId("spec:int:integer");
+        }
+
+        public static class Boolean
+        {
+            public static ForgeTypeId YesNo { get; } = new ForgeTypeId("spec:boolean:yesno");
+        }
+
+        public static class Reference
+        {
+            public static ForgeTypeId Material { get; } = new ForgeTypeId("spec:reference:material");
+        }
+
+        public static class Number
+        {
+            public static ForgeTypeId Number { get; } = new ForgeTypeId("spec:number");
+            public static ForgeTypeId Length { get; } = new ForgeTypeId("spec:length");
+            public static ForgeTypeId Area { get; } = new ForgeTypeId("spec:area");
+            public static ForgeTypeId Volume { get; } = new ForgeTypeId("spec:volume");
+            public static ForgeTypeId Angle { get; } = new ForgeTypeId("spec:angle");
+            public static ForgeTypeId HVACDensity { get; } = new ForgeTypeId("spec:hvac:density");
+            public static ForgeTypeId HVACPower { get; } = new ForgeTypeId("spec:hvac:power");
+            public static ForgeTypeId HVACTemperature { get; } = new ForgeTypeId("spec:hvac:temperature");
+            public static ForgeTypeId HVACAirflow { get; } = new ForgeTypeId("spec:hvac:airflow");
+            public static ForgeTypeId ElectricalCurrent { get; } = new ForgeTypeId("spec:electrical:current");
+            public static ForgeTypeId ElectricalPower { get; } = new ForgeTypeId("spec:electrical:power");
+        }
+    }
+}
+#endif

--- a/RevitExtensions.Tests/ParameterDefinitionExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterDefinitionExtensionsTests.cs
@@ -1,0 +1,21 @@
+#if REVIT2022_OR_LESS
+using Autodesk.Revit.DB;
+using RevitExtensions;
+using Xunit;
+
+namespace RevitExtensions.Tests
+{
+    public class ParameterDefinitionExtensionsTests
+    {
+        [Fact]
+        public void GetDataType_ReturnsMappedForgeTypeId()
+        {
+            var def = new Definition { ParameterType = ParameterType.Text };
+
+            var id = def.GetDataType();
+
+            Assert.Equal(SpecTypeId.String.Text.TypeId, id.TypeId);
+        }
+    }
+}
+#endif

--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -176,6 +176,16 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
+        public void SetParameterValue_Expression_Evaluated()
+        {
+            var parameter = new Parameter("A") { StorageType = StorageType.Double };
+
+            parameter.SetParameterValue("=1m + 50cm");
+
+            Assert.InRange(parameter.AsDouble(), 4.92, 4.93);
+        }
+
+        [Fact]
         public void TrySetParameterValue_ReadOnly_ReturnsFalseWithReason()
         {
             var parameter = new Parameter("A") { StorageType = StorageType.String, IsReadOnly = true };
@@ -205,6 +215,20 @@ namespace RevitExtensions.Tests
             element.SetParameterValue(ParameterIdentifier.Parse("10"), 5);
 
             Assert.Equal(5, parameter.AsInteger());
+        }
+
+        [Fact]
+        public void Element_SetParameterValue_Expression_UsesUnits()
+        {
+            var doc = new Document();
+            doc.SetTestLengthUnitScale(0.00328083989501312); // mm
+            var element = new Element(doc, new ElementId(1));
+            var parameter = new Parameter(new ElementId(11)) { StorageType = StorageType.Double };
+            element.Parameters.Add(parameter);
+
+            element.SetParameterValue(ParameterIdentifier.Parse("11"), "=10");
+
+            Assert.InRange(parameter.AsDouble(), 0.032, 0.033);
         }
 
         [Fact]

--- a/RevitExtensions/CustomConvert.cs
+++ b/RevitExtensions/CustomConvert.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using Autodesk.Revit.DB;
+using RevitExtensions.Utilities;
 
 namespace RevitExtensions
 {
@@ -74,6 +75,16 @@ namespace RevitExtensions
             }
         }
 
+        public static bool TryToDouble(object value, double unitScale, out double result)
+        {
+            if (value is string sv && sv.StartsWith("="))
+            {
+                return UnitExpressionEvaluator.TryEvaluate(sv, unitScale, out result);
+            }
+
+            return TryToDouble(value, out result);
+        }
+
         public static bool TryToInt32(object value, out int result)
         {
             result = default;
@@ -98,6 +109,22 @@ namespace RevitExtensions
                     }
                     return false;
             }
+        }
+
+        public static bool TryToInt32(object value, double unitScale, out int result)
+        {
+            if (value is string sv && sv.StartsWith("="))
+            {
+                if (UnitExpressionEvaluator.TryEvaluate(sv, unitScale, out var d))
+                {
+                    result = (int)Math.Round(d);
+                    return true;
+                }
+                result = default;
+                return false;
+            }
+
+            return TryToInt32(value, out result);
         }
 
         public static bool TryToElementId(object value, out ElementId? id)

--- a/RevitExtensions/DocumentUnitExtensions.cs
+++ b/RevitExtensions/DocumentUnitExtensions.cs
@@ -1,0 +1,31 @@
+using System.Runtime.CompilerServices;
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Provides helpers for working with document units in tests.
+    /// </summary>
+    public static class DocumentUnitExtensions
+    {
+        private class Data { public double LengthScale = 1.0; }
+        private static readonly ConditionalWeakTable<Document, Data> Cache = new ConditionalWeakTable<Document, Data>();
+
+        internal static double GetLengthUnitScale(this Document document)
+        {
+            return Cache.TryGetValue(document, out var data) ? data.LengthScale : 1.0;
+        }
+
+        /// <summary>
+        /// Sets the length unit scale used when evaluating expressions in tests.
+        /// A value of 1 represents feet, 0.00328084 for millimeters, etc.
+        /// </summary>
+        /// <param name="document">The document to configure.</param>
+        /// <param name="scale">The scale factor to convert document units to feet.</param>
+        public static void SetTestLengthUnitScale(this Document document, double scale)
+        {
+            var data = Cache.GetOrCreateValue(document);
+            data.LengthScale = scale;
+        }
+    }
+}

--- a/RevitExtensions/Models/ForgeTypeId.cs
+++ b/RevitExtensions/Models/ForgeTypeId.cs
@@ -1,0 +1,141 @@
+#if REVIT2021_OR_LESS
+using System;
+
+namespace Autodesk.Revit.DB
+{
+    /// <summary>
+    /// Backport of the ForgeTypeId class for Revit 2021 and earlier.
+    /// </summary>
+    public class ForgeTypeId : IEquatable<ForgeTypeId>
+    {
+        private string _typeId;
+
+        /// <summary>
+        /// Initializes a new, empty instance.
+        /// </summary>
+        public ForgeTypeId()
+        {
+            _typeId = string.Empty;
+        }
+
+        /// <summary>
+        /// Initializes with the specified id.
+        /// </summary>
+        /// <param name="typeId">The type identifier.</param>
+        public ForgeTypeId(string typeId)
+        {
+            _typeId = typeId ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Clears the value.
+        /// </summary>
+        public void Clear()
+        {
+            _typeId = string.Empty;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the identifier is empty.
+        /// </summary>
+        public bool Empty()
+        {
+            return string.IsNullOrEmpty(_typeId);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            return obj is ForgeTypeId other && NameEquals(other);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(ForgeTypeId? other)
+        {
+            return other != null && NameEquals(other);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return _typeId?.ToLowerInvariant().GetHashCode() ?? 0;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return _typeId;
+        }
+
+        /// <summary>
+        /// Compares the base names of two identifiers.
+        /// </summary>
+        public bool NameEquals(ForgeTypeId other)
+        {
+            if (other == null)
+                return false;
+
+            string thisBase = GetBaseTypeId(_typeId);
+            string otherBase = GetBaseTypeId(other._typeId);
+
+            return string.Equals(thisBase, otherBase, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Determines if the identifiers match exactly.
+        /// </summary>
+        public bool StrictlyEquals(ForgeTypeId other)
+        {
+            return other != null &&
+                   string.Equals(_typeId, other._typeId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetBaseTypeId(string typeId)
+        {
+            if (string.IsNullOrEmpty(typeId))
+                return string.Empty;
+
+            int dashIndex = typeId.IndexOf('-');
+            return dashIndex > 0 ? typeId.Substring(0, dashIndex) : typeId;
+        }
+
+        public static bool operator ==(ForgeTypeId? a, ForgeTypeId? b)
+        {
+            if (ReferenceEquals(a, b))
+                return true;
+            if (a is null || b is null)
+                return false;
+            return a.NameEquals(b);
+        }
+
+        public static bool operator !=(ForgeTypeId? a, ForgeTypeId? b)
+        {
+            return !(a == b);
+        }
+
+        public static bool operator <(ForgeTypeId? a, ForgeTypeId? b)
+        {
+            if (a is null || b is null)
+                return false;
+            return string.Compare(a._typeId, b._typeId, StringComparison.OrdinalIgnoreCase) < 0;
+        }
+
+        public static bool operator >(ForgeTypeId? a, ForgeTypeId? b)
+        {
+            if (a is null || b is null)
+                return false;
+            return string.Compare(a._typeId, b._typeId, StringComparison.OrdinalIgnoreCase) > 0;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this is a valid Revit API object.
+        /// </summary>
+        public bool IsValidObject => !string.IsNullOrEmpty(_typeId);
+
+        /// <summary>
+        /// Gets the type identifier string.
+        /// </summary>
+        public string TypeId => _typeId;
+    }
+}
+#endif

--- a/RevitExtensions/Models/SpecTypeId.cs
+++ b/RevitExtensions/Models/SpecTypeId.cs
@@ -1,0 +1,49 @@
+#if REVIT2022_OR_LESS
+namespace Autodesk.Revit.DB
+{
+    /// <summary>
+    /// Backport of the SpecTypeId class for versions lacking it.
+    /// Provides a minimal set of identifiers used by tests and extensions.
+    /// </summary>
+    public static class SpecTypeId
+    {
+        public static class String
+        {
+            public static ForgeTypeId Text { get; } = new ForgeTypeId("spec:string:text");
+            public static ForgeTypeId Multiline { get; } = new ForgeTypeId("spec:string:multiline");
+            public static ForgeTypeId Url { get; } = new ForgeTypeId("spec:string:url");
+            public static ForgeTypeId Custom { get; } = new ForgeTypeId("spec:string:custom");
+        }
+
+        public static class Int
+        {
+            public static ForgeTypeId Integer { get; } = new ForgeTypeId("spec:int:integer");
+        }
+
+        public static class Boolean
+        {
+            public static ForgeTypeId YesNo { get; } = new ForgeTypeId("spec:boolean:yesno");
+        }
+
+        public static class Reference
+        {
+            public static ForgeTypeId Material { get; } = new ForgeTypeId("spec:reference:material");
+        }
+
+        public static class Number
+        {
+            public static ForgeTypeId General { get; } = new ForgeTypeId("spec:number");
+            public static ForgeTypeId Length { get; } = new ForgeTypeId("spec:length");
+            public static ForgeTypeId Area { get; } = new ForgeTypeId("spec:area");
+            public static ForgeTypeId Volume { get; } = new ForgeTypeId("spec:volume");
+            public static ForgeTypeId Angle { get; } = new ForgeTypeId("spec:angle");
+            public static ForgeTypeId HVACDensity { get; } = new ForgeTypeId("spec:hvac:density");
+            public static ForgeTypeId HVACPower { get; } = new ForgeTypeId("spec:hvac:power");
+            public static ForgeTypeId HVACTemperature { get; } = new ForgeTypeId("spec:hvac:temperature");
+            public static ForgeTypeId HVACAirflow { get; } = new ForgeTypeId("spec:hvac:airflow");
+            public static ForgeTypeId ElectricalCurrent { get; } = new ForgeTypeId("spec:electrical:current");
+            public static ForgeTypeId ElectricalPower { get; } = new ForgeTypeId("spec:electrical:power");
+        }
+    }
+}
+#endif

--- a/RevitExtensions/ParameterDefinitionExtensions.cs
+++ b/RevitExtensions/ParameterDefinitionExtensions.cs
@@ -1,0 +1,25 @@
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Extension helpers for <see cref="Definition"/> to retrieve the data type consistently.
+    /// </summary>
+    public static class ParameterDefinitionExtensions
+    {
+        /// <summary>
+        /// Gets the parameter data type as a <see cref="ForgeTypeId"/> for all Revit versions.
+        /// </summary>
+        /// <param name="definition">The parameter definition.</param>
+        /// <returns>The data type identifier.</returns>
+        public static ForgeTypeId GetDataType(this Definition definition)
+        {
+#if REVIT2022_OR_LESS
+            return definition.ParameterType.ToForgeTypeId();
+#else
+            // For newer APIs this instance method already exists.
+            return definition.GetDataType();
+#endif
+        }
+    }
+}

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using Autodesk.Revit.DB;
 using System.Globalization;
 using RevitExtensions.Models;
+using RevitExtensions.Utilities;
 
 namespace RevitExtensions
 {
@@ -323,7 +324,9 @@ namespace RevitExtensions
         /// Sets the value of the parameter.
         /// </summary>
         /// <param name="parameter">The parameter.</param>
-        /// <param name="value">The value to set.</param>
+        /// <param name="value">The value to set. Strings starting with '=' are
+        /// evaluated as arithmetic expressions supporting m, cm, mm, ft and in
+        /// units.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
         /// <exception cref="InvalidOperationException">Thrown when setting the value fails.</exception>
         public static void SetParameterValue(this Parameter parameter, object value)
@@ -336,7 +339,9 @@ namespace RevitExtensions
         /// Sets the value of the parameter.
         /// </summary>
         /// <param name="parameter">The parameter.</param>
-        /// <param name="value">The value to set.</param>
+        /// <param name="value">The value to set. Strings starting with '=' are
+        /// evaluated as arithmetic expressions supporting m, cm, mm, ft and in
+        /// units.</param>
         /// <param name="reason">Outputs the failure reason.</param>
         /// <returns>True if successful.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
@@ -357,7 +362,9 @@ namespace RevitExtensions
             {
                 case StorageType.Double:
                     double d;
-                    if (!CustomConvert.TryToDouble(value, out d))
+                    var doc = parameter.Element?.Document;
+                    var dScale = doc != null ? doc.GetLengthUnitScale() : 1.0;
+                    if (!CustomConvert.TryToDouble(value, dScale, out d))
                     {
                         reason = "Value must be a number.";
                         return false;
@@ -368,7 +375,9 @@ namespace RevitExtensions
                     break;
                 case StorageType.Integer:
                     int i;
-                    if (!CustomConvert.TryToInt32(value, out i))
+                    doc = parameter.Element?.Document;
+                    var iScale = doc != null ? doc.GetLengthUnitScale() : 1.0;
+                    if (!CustomConvert.TryToInt32(value, iScale, out i))
                     {
                         reason = "Value must be an integer.";
                         return false;
@@ -549,5 +558,6 @@ namespace RevitExtensions
             }
             return null;
         }
+
     }
 }

--- a/RevitExtensions/ParameterTypeExtensions.cs
+++ b/RevitExtensions/ParameterTypeExtensions.cs
@@ -1,0 +1,41 @@
+#if REVIT2022_OR_LESS
+using Autodesk.Revit.DB;
+
+namespace RevitExtensions
+{
+    /// <summary>
+    /// Extension helpers for the deprecated <see cref="ParameterType"/> enum.
+    /// </summary>
+    public static class ParameterTypeExtensions
+    {
+        /// <summary>
+        /// Maps a <see cref="ParameterType"/> to its <see cref="ForgeTypeId"/> equivalent.
+        /// </summary>
+        public static ForgeTypeId ToForgeTypeId(this ParameterType pt)
+        {
+            return pt switch
+            {
+                ParameterType.Text => SpecTypeId.String.Text,
+                ParameterType.MultilineText => SpecTypeId.String.Multiline,
+                ParameterType.URL => SpecTypeId.String.Url,
+                ParameterType.Integer => SpecTypeId.Int.Integer,
+                ParameterType.YesNo => SpecTypeId.Boolean.YesNo,
+                ParameterType.Material => SpecTypeId.Reference.Material,
+                ParameterType.Number => SpecTypeId.Number.General,
+                ParameterType.FixtureUnit => SpecTypeId.Number.General,
+                ParameterType.Length => SpecTypeId.Number.Length,
+                ParameterType.Area => SpecTypeId.Number.Area,
+                ParameterType.Volume => SpecTypeId.Number.Volume,
+                ParameterType.Angle => SpecTypeId.Number.Angle,
+                ParameterType.HVACDensity => SpecTypeId.Number.HVACDensity,
+                ParameterType.HVACPower => SpecTypeId.Number.HVACPower,
+                ParameterType.HVACTemperature => SpecTypeId.Number.HVACTemperature,
+                ParameterType.HVACAirflow => SpecTypeId.Number.HVACAirflow,
+                ParameterType.ElectricalCurrent => SpecTypeId.Number.ElectricalCurrent,
+                ParameterType.ElectricalPower => SpecTypeId.Number.ElectricalPower,
+                _ => SpecTypeId.String.Text,
+            };
+        }
+    }
+}
+#endif

--- a/RevitExtensions/Utilities/UnitExpressionEvaluator.cs
+++ b/RevitExtensions/Utilities/UnitExpressionEvaluator.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Data;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace RevitExtensions.Utilities
+{
+    /// <summary>
+    /// Evaluates arithmetic expressions containing length units.
+    /// Supported units are meters (m), centimeters (cm), millimeters (mm),
+    /// feet (ft) and inches (in).
+    /// </summary>
+    internal static class UnitExpressionEvaluator
+    {
+        private const double FeetPerMeter = 3.28083989501312;
+        private const double FeetPerCentimeter = 0.0328083989501312;
+        private const double FeetPerMillimeter = 0.00328083989501312;
+
+        private static readonly Regex TokenRegex =
+            new Regex(@"(-?\d+(?:\.\d+)?)(?:\s*(m|cm|mm|ft|in))?",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public static bool TryEvaluate(string expression, double defaultScale, out double value)
+        {
+            value = 0;
+            if (string.IsNullOrWhiteSpace(expression))
+                return false;
+
+            var expr = expression.Trim();
+            if (expr.StartsWith("="))
+                expr = expr.Substring(1);
+
+            expr = TokenRegex.Replace(expr, m =>
+            {
+                var number = double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
+                var unit = m.Groups[2].Value.ToLowerInvariant();
+                double scaled = unit switch
+                {
+                    "m" => number * FeetPerMeter,
+                    "cm" => number * FeetPerCentimeter,
+                    "mm" => number * FeetPerMillimeter,
+                    "ft" => number,
+                    "in" => number / 12.0,
+                    _ => number * defaultScale
+                };
+                return scaled.ToString(CultureInfo.InvariantCulture);
+            });
+
+            try
+            {
+                using var table = new DataTable { Locale = CultureInfo.InvariantCulture };
+                var resultObj = table.Compute(expr, null);
+                value = Convert.ToDouble(resultObj, CultureInfo.InvariantCulture);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- link parameters to their element in stubs
- simplify document lookup for unit expressions
- support expressions when setting parameter values
- centralize expression parsing in `CustomConvert`
- backport `ForgeTypeId` for Revit 2021 and older
- add `ParameterType` mapping and `Definition.GetDataType` helpers for old APIs

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`
- `./build.sh --target BuildAll`


------
https://chatgpt.com/codex/tasks/task_e_6860fc82eb1c8326826a8e3a8d346f96