### PR TITLE
Check element edit status in TrySetParameterValue

### DIFF
--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -210,6 +210,22 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
+        public void TrySetParameterValue_ElementNotEditable_ReturnsFalseWithReason()
+        {
+            var doc = new Document { IsWorkshared = true, CurrentUser = "A" };
+            var id = new ElementId(101);
+            doc.SetElementOwner(id, "B");
+            var element = new Element(doc, id);
+            var parameter = new Parameter("E") { StorageType = StorageType.String };
+            element.Parameters.Add(parameter);
+
+            var result = parameter.TrySetParameterValue("foo", out var reason);
+
+            Assert.False(result);
+            Assert.Equal(EditStatus.OwnedByOtherUser.ToFriendlyString(), reason);
+        }
+
+        [Fact]
         public void SetParameterValue_ReadOnly_Throws()
         {
             var parameter = new Parameter("A") { StorageType = StorageType.String, IsReadOnly = true };

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -337,6 +337,13 @@ namespace RevitExtensions
 
             reason = null;
 
+            var owner = parameter.Element;
+            if (owner != null && !owner.CanEdit(out var status))
+            {
+                reason = status.ToFriendlyString();
+                return false;
+            }
+
             if (parameter.IsReadOnly)
             {
                 reason = "Parameter is read-only.";


### PR DESCRIPTION
## Summary
- ensure parameters can't be edited when their element is locked
- report the lock status description as the failure reason
- test that TrySetParameterValue returns the element's edit status string

## Testing
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true`
- `./build.sh --target BuildAll`


------
https://chatgpt.com/codex/tasks/task_e_6866177b90048326a4a8a9d732b41515