### PR TITLE
Add linked model checks earlier

### DIFF
--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -172,6 +172,11 @@ namespace Autodesk.Revit.DB
         public ParameterSet Parameters { get; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the element can be modified.
+        /// </summary>
+        public bool IsModifiable { get; set; } = true;
+
+        /// <summary>
         /// Gets a value indicating whether <see cref="Dispose"/> has been called.
         /// </summary>
         public bool IsDisposed { get; private set; }
@@ -253,7 +258,8 @@ namespace Autodesk.Revit.DB
     {
         public bool IsWorkshared { get; set; }
         public string CurrentUser { get; set; }
-        public bool IsModifiable { get; set; }
+        public bool IsModifiable { get; set; } = true;
+        public bool IsLinked { get; set; }
 
         /// <summary>
         /// Gets or sets the application associated with the document.

--- a/RevitExtensions.Tests/ElementExtensionsTests.cs
+++ b/RevitExtensions.Tests/ElementExtensionsTests.cs
@@ -132,5 +132,29 @@ namespace RevitExtensions.Tests
 
             Assert.Null(result);
         }
+
+        [Fact]
+        public void CanEdit_ModelLocked_ReturnsFalse()
+        {
+            var doc = new Document { IsWorkshared = true, CurrentUser = "A" };
+            var element = new Element(doc, new ElementId(14)) { IsModifiable = false };
+
+            var result = element.CanEdit(out var status);
+
+            Assert.False(result);
+            Assert.Equal(EditStatus.ModelLocked, status);
+        }
+
+        [Fact]
+        public void CanEdit_LinkedModel_ReturnsFalse()
+        {
+            var doc = new Document { IsWorkshared = true, CurrentUser = "A", IsLinked = true };
+            var element = new Element(doc, new ElementId(15));
+
+            var result = element.CanEdit(out var status);
+
+            Assert.False(result);
+            Assert.Equal(EditStatus.LinkedModel, status);
+        }
     }
 }

--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -226,6 +226,34 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
+        public void TrySetParameterValue_ElementLocked_ReturnsFalseWithReason()
+        {
+            var doc = new Document { IsWorkshared = true, CurrentUser = "A" };
+            var element = new Element(doc, new ElementId(102)) { IsModifiable = false };
+            var parameter = new Parameter("F") { StorageType = StorageType.String };
+            element.Parameters.Add(parameter);
+
+            var result = parameter.TrySetParameterValue("foo", out var reason);
+
+            Assert.False(result);
+            Assert.Equal(EditStatus.ModelLocked.ToFriendlyString(), reason);
+        }
+
+        [Fact]
+        public void TrySetParameterValue_ElementInLinkedModel_ReturnsFalseWithReason()
+        {
+            var doc = new Document { IsWorkshared = true, CurrentUser = "A", IsLinked = true };
+            var element = new Element(doc, new ElementId(103));
+            var parameter = new Parameter("G") { StorageType = StorageType.String };
+            element.Parameters.Add(parameter);
+
+            var result = parameter.TrySetParameterValue("foo", out var reason);
+
+            Assert.False(result);
+            Assert.Equal(EditStatus.LinkedModel.ToFriendlyString(), reason);
+        }
+
+        [Fact]
         public void SetParameterValue_ReadOnly_Throws()
         {
             var parameter = new Parameter("A") { StorageType = StorageType.String, IsReadOnly = true };

--- a/RevitExtensions/EditStatus.cs
+++ b/RevitExtensions/EditStatus.cs
@@ -26,6 +26,16 @@ namespace RevitExtensions
         /// The element is owned by another user.
         /// </summary>
         OwnedByOtherUser,
+
+        /// <summary>
+        /// The model is temporarily locked and the element cannot be modified.
+        /// </summary>
+        ModelLocked,
+
+        /// <summary>
+        /// The element resides in a linked model.
+        /// </summary>
+        LinkedModel,
     }
 
     /// <summary>
@@ -50,6 +60,10 @@ namespace RevitExtensions
                     return "Owned by current user";
                 case EditStatus.OwnedByOtherUser:
                     return "Owned by another user";
+                case EditStatus.ModelLocked:
+                    return "Model is temporarily locked";
+                case EditStatus.LinkedModel:
+                    return "Element is in a linked model";
                 default:
                     return status.ToString();
             }


### PR DESCRIPTION
## Summary
- check `Document.IsLinked` starting with Revit 2020
- keep `Element.IsModifiable` check for Revit 2024 and newer

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true -p:DefineConstants=REVIT2026%3BREVIT2026_OR_ABOVE%3BREVIT2025_OR_ABOVE%3BREVIT2024_OR_ABOVE%3BREVIT2020_OR_ABOVE`


------
https://chatgpt.com/codex/tasks/task_e_6866204a6e54832688dd0d09e2832adc