### PR TITLE
Add Workset parameter setters

### DIFF
--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -40,6 +40,40 @@ namespace Autodesk.Revit.DB
         }
     }
 
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.WorksetId.
+    /// </summary>
+    public class WorksetId
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorksetId"/> class.
+        /// </summary>
+        /// <param name="id">The integer value.</param>
+        public WorksetId(int id) => IntegerValue = id;
+
+        /// <summary>
+        /// Gets the value of the workset id as an integer.
+        /// </summary>
+        public int IntegerValue { get; }
+    }
+
+    /// <summary>
+    /// Minimal stand-in for Autodesk.Revit.DB.Workset.
+    /// </summary>
+    public class Workset
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Workset"/> class.
+        /// </summary>
+        /// <param name="id">The workset id.</param>
+        public Workset(WorksetId id) => Id = id;
+
+        /// <summary>
+        /// Gets the workset id.
+        /// </summary>
+        public WorksetId Id { get; }
+    }
+
 #if REVIT2021_OR_LESS
     public enum UnitType
     {
@@ -552,7 +586,13 @@ namespace Autodesk.Revit.DB
         }
     }
 
-    public enum BuiltInParameter { }
+    public enum BuiltInParameter
+    {
+        /// <summary>
+        /// Identifies the workset parameter on an element.
+        /// </summary>
+        ELEM_PARTITION_PARAM = -201
+    }
 
     public enum StorageType
     {

--- a/RevitExtensions.Tests/ElementExtensionsTests.cs
+++ b/RevitExtensions.Tests/ElementExtensionsTests.cs
@@ -156,5 +156,30 @@ namespace RevitExtensions.Tests
             Assert.False(result);
             Assert.Equal(EditStatus.LinkedModel, status);
         }
+
+        [Fact]
+        public void SetWorkset_ById_UpdatesParameter()
+        {
+            var element = new Element(new ElementId(20));
+            var parameter = new Parameter(BuiltInParameter.ELEM_PARTITION_PARAM) { StorageType = StorageType.Integer };
+            element.Parameters.Add(parameter);
+
+            element.SetWorkset(new WorksetId(3));
+
+            Assert.Equal(3, parameter.AsInteger());
+        }
+
+        [Fact]
+        public void SetWorkset_ByWorkset_UpdatesParameter()
+        {
+            var element = new Element(new ElementId(21));
+            var parameter = new Parameter(BuiltInParameter.ELEM_PARTITION_PARAM) { StorageType = StorageType.Integer };
+            element.Parameters.Add(parameter);
+            var ws = new Workset(new WorksetId(5));
+
+            element.SetWorkset(ws);
+
+            Assert.Equal(5, parameter.AsInteger());
+        }
     }
 }

--- a/RevitExtensions/CustomConverter.cs
+++ b/RevitExtensions/CustomConverter.cs
@@ -29,6 +29,8 @@ namespace RevitExtensions
             Register(new LongToElementIdConverter());
             Register(new StringToElementIdConverter());
             Register(new ElementIdToLongConverter());
+            Register(new WorksetToIntConverter());
+            Register(new WorksetIdToIntConverter());
         }
 
         /// <summary>
@@ -255,6 +257,30 @@ namespace RevitExtensions
             public bool TryConvert(ElementId value, Parameter parameter, out long result)
             {
                 result = value.GetElementIdValue();
+                return true;
+            }
+        }
+
+        private class WorksetToIntConverter : IParameterConverter<Workset, int>
+        {
+            public bool TryConvert(Workset value, Parameter parameter, out int result)
+            {
+                if (value == null)
+                {
+                    result = default;
+                    return false;
+                }
+
+                result = value.Id.IntegerValue;
+                return true;
+            }
+        }
+
+        private class WorksetIdToIntConverter : IParameterConverter<WorksetId, int>
+        {
+            public bool TryConvert(WorksetId value, Parameter parameter, out int result)
+            {
+                result = value.IntegerValue;
                 return true;
             }
         }

--- a/RevitExtensions/ElementExtensions.cs
+++ b/RevitExtensions/ElementExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Autodesk.Revit.DB;
+using RevitExtensions.Models;
 
 namespace RevitExtensions
 {
@@ -158,6 +159,34 @@ namespace RevitExtensions
             if (typeId == null) return null;
 
             return document.GetElement(typeId);
+        }
+
+        /// <summary>
+        /// Assigns the element to the specified workset.
+        /// </summary>
+        /// <param name="element">The element to modify.</param>
+        /// <param name="workset">The workset to assign.</param>
+        public static void SetWorkset(this Element element, Workset workset)
+        {
+            if (workset == null) throw new ArgumentNullException(nameof(workset));
+            element.SetWorkset(workset.Id);
+        }
+
+        /// <summary>
+        /// Assigns the element to the specified workset.
+        /// </summary>
+        /// <param name="element">The element to modify.</param>
+        /// <param name="worksetId">The workset id to assign.</param>
+        public static void SetWorkset(this Element element, WorksetId worksetId)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (worksetId == null) throw new ArgumentNullException(nameof(worksetId));
+
+            var identifier = new ParameterIdentifier
+            {
+                BuiltInParameter = BuiltInParameter.ELEM_PARTITION_PARAM
+            };
+            element.SetParameterValue(identifier, worksetId);
         }
     }
 }


### PR DESCRIPTION
## Summary
- support converting Workset/WorksetId to integer
- add stub `ELEM_PARTITION_PARAM` for workset parameter
- use built-in parameter when assigning worksets
- update workset tests

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true` *(fails: Assert.False() Failure)*
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true -p:DefineConstants="REVIT2026%3BREVIT2019_OR_ABOVE%3BREVIT2020_OR_ABOVE%3BREVIT2021_OR_ABOVE%3BREVIT2022_OR_ABOVE%3BREVIT2023_OR_ABOVE%3BREVIT2024_OR_ABOVE%3BREVIT2025_OR_ABOVE%3BREVIT2026_OR_ABOVE%3BREVIT2026_OR_LESS"`

------
https://chatgpt.com/codex/tasks/task_e_68668d85e5dc8326960e9470e0c87be5