### PR TITLE
Add ParameterValue converter classes

### DIFF
--- a/RevitApiStubs/Autodesk.Revit.DB.cs
+++ b/RevitApiStubs/Autodesk.Revit.DB.cs
@@ -647,6 +647,17 @@ namespace Autodesk.Revit.DB
 #endif
     }
 
+    /// <summary>
+    /// Simplified stand-in for Autodesk.Revit.DB.InternalDefinition.
+    /// </summary>
+    public class InternalDefinition : Definition
+    {
+        /// <summary>
+        /// Gets or sets the associated built-in parameter id.
+        /// </summary>
+        public BuiltInParameter BuiltInParameter { get; set; }
+    }
+
     public class Parameter : IDisposable
     {
         public BuiltInParameter? BuiltInParameter { get; }

--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -394,5 +394,50 @@ namespace RevitExtensions.Tests
 
             Assert.Equal(dt, value);
         }
+
+        [Fact]
+        public void GetParameterValueDetailed_FromParameter_ReturnsDetails()
+        {
+            var parameter = new Parameter("F") { StorageType = StorageType.Integer };
+            parameter.Set(5);
+
+            var detailed = parameter.GetParameterValueDetailed();
+
+            Assert.Equal(5, detailed.Value);
+            Assert.Equal(parameter.AsValueString(), detailed.ValueString);
+            Assert.Equal(ParameterValueType.Integer, detailed.ValueType);
+        }
+
+        [Fact]
+        public void Element_GetParameterValueDetailed_ReturnsDetails()
+        {
+            var element = new Element(new ElementId(1));
+            var parameter = new Parameter(new ElementId(20)) { StorageType = StorageType.Double };
+#if REVIT2021_OR_LESS
+            parameter.Definition.ParameterType = ParameterType.Length;
+#else
+            parameter.Definition.DataType = SpecTypeId.Length;
+#endif
+            parameter.Set(3.5);
+            element.Parameters.Add(parameter);
+
+            var detailed = element.GetParameterValueDetailed(ParameterIdentifier.Parse("20"));
+
+            Assert.NotNull(detailed);
+            Assert.Equal(3.5, detailed.Value);
+            Assert.Equal(parameter.AsValueString(), detailed.ValueString);
+            Assert.Equal(ParameterValueType.Number, detailed.ValueType);
+        }
+
+        [Fact]
+        public void GetParameterValueDetailed_WorksetParameter_ReturnsWorksetType()
+        {
+            var parameter = new Parameter(BuiltInParameter.ELEM_PARTITION_PARAM) { StorageType = StorageType.ElementId };
+            parameter.Set(new ElementId(42));
+
+            var detailed = parameter.GetParameterValueDetailed();
+
+            Assert.Equal(ParameterValueType.Workset, detailed.ValueType);
+        }
     }
 }

--- a/RevitExtensions.Tests/ParameterExtensionsTests.cs
+++ b/RevitExtensions.Tests/ParameterExtensionsTests.cs
@@ -396,12 +396,12 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
-        public void GetParameterValueDetailed_FromParameter_ReturnsDetails()
+        public void GetValueDetailed_FromParameter_ReturnsDetails()
         {
             var parameter = new Parameter("F") { StorageType = StorageType.Integer };
             parameter.Set(5);
 
-            var detailed = parameter.GetParameterValueDetailed();
+            var detailed = parameter.GetValueDetailed();
 
             Assert.Equal(5, detailed.Value);
             Assert.Equal(parameter.AsValueString(), detailed.ValueString);
@@ -409,7 +409,7 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
-        public void Element_GetParameterValueDetailed_ReturnsDetails()
+        public void Element_GetValueDetailed_ReturnsDetails()
         {
             var element = new Element(new ElementId(1));
             var parameter = new Parameter(new ElementId(20)) { StorageType = StorageType.Double };
@@ -421,7 +421,7 @@ namespace RevitExtensions.Tests
             parameter.Set(3.5);
             element.Parameters.Add(parameter);
 
-            var detailed = element.GetParameterValueDetailed(ParameterIdentifier.Parse("20"));
+            var detailed = element.GetValueDetailed(ParameterIdentifier.Parse("20"));
 
             Assert.NotNull(detailed);
             Assert.Equal(3.5, detailed.Value);
@@ -430,12 +430,12 @@ namespace RevitExtensions.Tests
         }
 
         [Fact]
-        public void GetParameterValueDetailed_WorksetParameter_ReturnsWorksetType()
+        public void GetValueDetailed_WorksetParameter_ReturnsWorksetType()
         {
             var parameter = new Parameter(BuiltInParameter.ELEM_PARTITION_PARAM) { StorageType = StorageType.ElementId };
             parameter.Set(new ElementId(42));
 
-            var detailed = parameter.GetParameterValueDetailed();
+            var detailed = parameter.GetValueDetailed();
 
             Assert.Equal(ParameterValueType.Workset, detailed.ValueType);
         }

--- a/RevitExtensions/CustomConverter.cs
+++ b/RevitExtensions/CustomConverter.cs
@@ -359,14 +359,12 @@ namespace RevitExtensions
 
             BuiltInParameter? bip = null;
 
-            var prop = parameter.GetType().GetProperty("BuiltInParameter");
-            if (prop != null)
+            if (parameter.Definition is InternalDefinition internalDef)
             {
-                var val = prop.GetValue(parameter);
-                if (val is BuiltInParameter b)
-                    bip = b;
+                bip = internalDef.BuiltInParameter;
             }
-            else if (parameter.Id != null)
+
+            if (!bip.HasValue && parameter.Id != null)
             {
                 var intValue = (int)parameter.Id.GetElementIdValue();
                 if (intValue < 0)

--- a/RevitExtensions/CustomConverter.cs
+++ b/RevitExtensions/CustomConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Autodesk.Revit.DB;
 using RevitExtensions.Utilities;
+using RevitExtensions.Models;
 
 namespace RevitExtensions
 {
@@ -289,11 +290,11 @@ namespace RevitExtensions
             }
         }
 
-        private class StringToParameterValueConverter : IParameterConverter<string, Models.ParameterValue>
+        private class StringToParameterValueConverter : IParameterConverter<string, ParameterValueDetailed>
         {
-            public bool TryConvert(string value, Parameter parameter, out Models.ParameterValue result)
+            public bool TryConvert(string value, Parameter parameter, out ParameterValueDetailed result)
             {
-                result = new Models.ParameterValue
+                result = new ParameterValueDetailed
                 {
                     Value = value,
                     ValueString = parameter.AsValueString(),
@@ -303,11 +304,11 @@ namespace RevitExtensions
             }
         }
 
-        private class IntToParameterValueConverter : IParameterConverter<int, Models.ParameterValue>
+        private class IntToParameterValueConverter : IParameterConverter<int, ParameterValueDetailed>
         {
-            public bool TryConvert(int value, Parameter parameter, out Models.ParameterValue result)
+            public bool TryConvert(int value, Parameter parameter, out ParameterValueDetailed result)
             {
-                result = new Models.ParameterValue
+                result = new ParameterValueDetailed
                 {
                     Value = value,
                     ValueString = parameter.AsValueString(),
@@ -317,11 +318,11 @@ namespace RevitExtensions
             }
         }
 
-        private class DoubleToParameterValueConverter : IParameterConverter<double, Models.ParameterValue>
+        private class DoubleToParameterValueConverter : IParameterConverter<double, ParameterValueDetailed>
         {
-            public bool TryConvert(double value, Parameter parameter, out Models.ParameterValue result)
+            public bool TryConvert(double value, Parameter parameter, out ParameterValueDetailed result)
             {
-                result = new Models.ParameterValue
+                result = new ParameterValueDetailed
                 {
                     Value = value,
                     ValueString = parameter.AsValueString(),
@@ -331,9 +332,9 @@ namespace RevitExtensions
             }
         }
 
-        private class ElementIdToParameterValueConverter : IParameterConverter<ElementId, Models.ParameterValue>
+        private class ElementIdToParameterValueConverter : IParameterConverter<ElementId, ParameterValueDetailed>
         {
-            public bool TryConvert(ElementId value, Parameter parameter, out Models.ParameterValue result)
+            public bool TryConvert(ElementId value, Parameter parameter, out ParameterValueDetailed result)
             {
                 if (value == null)
                 {
@@ -341,7 +342,7 @@ namespace RevitExtensions
                     return false;
                 }
 
-                result = new Models.ParameterValue
+                result = new ParameterValueDetailed
                 {
                     Value = value,
                     ValueString = parameter.AsValueString(),

--- a/RevitExtensions/Models/ParameterValue.cs
+++ b/RevitExtensions/Models/ParameterValue.cs
@@ -1,0 +1,40 @@
+namespace RevitExtensions.Models
+{
+    /// <summary>
+    /// Specifies the type of a parameter value.
+    /// </summary>
+    public enum ParameterValueType
+    {
+        /// <summary>Textual value.</summary>
+        Text,
+        /// <summary>Integer value.</summary>
+        Integer,
+        /// <summary>Numeric value.</summary>
+        Number,
+        /// <summary>Element identifier.</summary>
+        Element,
+        /// <summary>Workset identifier.</summary>
+        Workset,
+    }
+
+    /// <summary>
+    /// Represents a value assigned to a parameter.
+    /// </summary>
+    public class ParameterValue
+    {
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        public object? Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the string representation of the value.
+        /// </summary>
+        public string? ValueString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value type.
+        /// </summary>
+        public ParameterValueType ValueType { get; set; }
+    }
+}

--- a/RevitExtensions/Models/ParameterValueDetailed.cs
+++ b/RevitExtensions/Models/ParameterValueDetailed.cs
@@ -20,7 +20,7 @@ namespace RevitExtensions.Models
     /// <summary>
     /// Represents a value assigned to a parameter.
     /// </summary>
-    public class ParameterValue
+    public class ParameterValueDetailed
     {
         /// <summary>
         /// Gets or sets the value.

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -149,11 +149,11 @@ namespace RevitExtensions
         /// <param name="parameter">The parameter.</param>
         /// <returns>A <see cref="ParameterValueDetailed"/> instance.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
-        public static ParameterValueDetailed GetParameterValueDetailed(this Parameter parameter)
+        public static ParameterValueDetailed GetValueDetailed(this Parameter parameter)
         {
             if (parameter == null) throw new ArgumentNullException(nameof(parameter));
 
-            return GetValueDetailed(parameter);
+            return BuildValueDetailed(parameter);
         }
 
         /// <summary>
@@ -223,12 +223,12 @@ namespace RevitExtensions
         /// <param name="identifier">The parameter identifier string.</param>
         /// <returns>The detailed parameter value or null.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
-        public static ParameterValueDetailed? GetParameterValueDetailed(this Element element, string identifier)
+        public static ParameterValueDetailed? GetValueDetailed(this Element element, string identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
 
-            return element.GetParameterValueDetailed(ParameterIdentifier.Parse(identifier));
+            return element.GetValueDetailed(ParameterIdentifier.Parse(identifier));
         }
 
         /// <summary>
@@ -238,13 +238,13 @@ namespace RevitExtensions
         /// <param name="identifier">The parameter identifier.</param>
         /// <returns>The detailed parameter value or null.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="element"/> or <paramref name="identifier"/> is null.</exception>
-        public static ParameterValueDetailed? GetParameterValueDetailed(this Element element, ParameterIdentifier identifier)
+        public static ParameterValueDetailed? GetValueDetailed(this Element element, ParameterIdentifier identifier)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
 
             using var parameter = element.GetParameter(identifier);
-            return parameter?.GetParameterValueDetailed();
+            return parameter?.GetValueDetailed();
         }
 
         /// <summary>
@@ -601,7 +601,7 @@ namespace RevitExtensions
             return defaultType;
         }
 
-        private static ParameterValueDetailed GetValueDetailed(Parameter parameter)
+        private static ParameterValueDetailed BuildValueDetailed(Parameter parameter)
         {
             var value = parameter.GetParameterValue();
 

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -548,14 +548,9 @@ namespace RevitExtensions
                 identifier.Guid = guid.Value;
             }
 
-            var bipProp = parameter.GetType().GetProperty("BuiltInParameter");
-            if (bipProp != null)
+            if (parameter.Definition is InternalDefinition internalDef)
             {
-                var bipValue = bipProp.GetValue(parameter);
-                if (bipValue is BuiltInParameter bip)
-                {
-                    identifier.BuiltInParameter = bip;
-                }
+                identifier.BuiltInParameter = internalDef.BuiltInParameter;
             }
 
             if (parameter.Id != null)
@@ -595,14 +590,12 @@ namespace RevitExtensions
 
             BuiltInParameter? bip = null;
 
-            var prop = parameter.GetType().GetProperty("BuiltInParameter");
-            if (prop != null)
+            if (parameter.Definition is InternalDefinition internalDef)
             {
-                var val = prop.GetValue(parameter);
-                if (val is BuiltInParameter b)
-                    bip = b;
+                bip = internalDef.BuiltInParameter;
             }
-            else if (parameter.Id != null)
+
+            if (!bip.HasValue && parameter.Id != null)
             {
                 var intValue = (int)parameter.Id.GetElementIdValue();
                 if (intValue < 0)

--- a/RevitExtensions/ParameterExtensions.cs
+++ b/RevitExtensions/ParameterExtensions.cs
@@ -153,14 +153,7 @@ namespace RevitExtensions
         {
             if (parameter == null) throw new ArgumentNullException(nameof(parameter));
 
-            var value = parameter.GetParameterValue();
-
-            return new ParameterValueDetailed
-            {
-                Value = value,
-                ValueString = parameter.AsValueString(),
-                ValueType = GetParameterValueType(parameter),
-            };
+            return GetValueDetailed(parameter);
         }
 
         /// <summary>
@@ -606,6 +599,18 @@ namespace RevitExtensions
                 return ParameterValueType.Workset;
 
             return defaultType;
+        }
+
+        private static ParameterValueDetailed GetValueDetailed(Parameter parameter)
+        {
+            var value = parameter.GetParameterValue();
+
+            return new ParameterValueDetailed
+            {
+                Value = value,
+                ValueString = parameter.AsValueString(),
+                ValueType = GetParameterValueType(parameter),
+            };
         }
 
         private static Guid? TryGetGuid(Parameter parameter)


### PR DESCRIPTION
## Summary
- add `ParameterValue` model and `ParameterValueType` enum
- hook up `IParameterConverter` implementations for converting
  string/int/double/ElementId values to `ParameterValue`
- use `AsValueString()` from `Parameter` when filling `ValueString`
- treat `ELEM_PARTITION_PARAM` values as `Workset` type

## Testing
- `./build.sh --target BuildAll`
- `dotnet test RevitExtensions.sln -c Release -p:UseRevitApiStubs=true` *(fails: CanEdit_LinkedModel_ReturnsFalse, CanEdit_ModelLocked_ReturnsFalse, TrySetParameterValue_ElementInLinkedModel_ReturnsFalseWithReason, TrySetParameterValue_ElementLocked_ReturnsFalseWithReason)*

------
https://chatgpt.com/codex/tasks/task_e_6866c8915dd88326a1076652cb2036d9